### PR TITLE
refactor(core): defer init() to post-creation and expose orchestrator property

### DIFF
--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -12,19 +12,17 @@ import uuid
 from collections import deque
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import pykka
 from pydantic import BaseModel
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_address_impl import ActorAddressImpl
+from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.message import Message
 from akgentic.core.utils.deserializer import import_class
-
-if TYPE_CHECKING:
-    from akgentic.core.agent import Akgent
 
 # Logger for agent operations
 logger = logging.getLogger(__name__)
@@ -314,7 +312,9 @@ class ActorSystem(ExecutionContext):
             team_id=team_id,
             restoring=restoring,
         )
-        return ActorAddressImpl(actor)
+        actor_addr = ActorAddressImpl(actor)
+        self.proxy_tell(actor_addr, Akgent).init()
+        return actor_addr
 
     @contextmanager
     def private(self) -> Generator[ExecutionContext, None, None]:

--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -313,7 +313,6 @@ class ActorSystem(ExecutionContext):
             restoring=restoring,
         )
         actor_addr = ActorAddressImpl(actor)
-        self.proxy_tell(actor_addr, Akgent).init()
         return actor_addr
 
     @contextmanager

--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -249,7 +249,7 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
             )
         )
 
-    def init(self) -> None:
+    def on_start(self) -> None:
         """Custom initialization hook, to be overridden by subclasses.
 
         Called after __init__ completes. Use for agent-specific setup
@@ -313,8 +313,6 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
             parent=self.myAddress,
             orchestrator=self._orchestrator,
         )
-        actor_addr = ActorAddressImpl(actor)
-        self.proxy_tell(actor_addr, Akgent).init()
         self._children.append(ActorAddressImpl(actor))
 
         return ActorAddressImpl(actor)

--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -248,7 +248,6 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
                 parent=self._parent,
             )
         )
-        self.init()
 
     def init(self) -> None:
         """Custom initialization hook, to be overridden by subclasses.
@@ -266,6 +265,15 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
             ActorAddress wrapping this agent's pykka actor reference.
         """
         return ActorAddressImpl(self.actor_ref)
+
+    @property
+    def orchestrator(self) -> ActorAddress | None:
+        """Get the orchestrator address.
+
+        Returns:
+            ActorAddress of the orchestrator if available, None otherwise.
+        """
+        return self._orchestrator
 
     def createActor(  # noqa: N802
         self,
@@ -305,6 +313,8 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
             parent=self.myAddress,
             orchestrator=self._orchestrator,
         )
+        actor_addr = ActorAddressImpl(actor)
+        self.proxy_tell(actor_addr, Akgent).init()
         self._children.append(ActorAddressImpl(actor))
 
         return ActorAddressImpl(actor)

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -165,7 +165,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
     """
 
     @override
-    def init(self) -> None:
+    def on_start(self) -> None:
         """Initialize the Orchestrator with empty in-memory state.
 
         The inactivity timer delay is configurable via the
@@ -406,10 +406,10 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         return active
 
     def get_team_member(self, name: str) -> ActorAddress | None:
-        """Get a team member by name or agent_id.
+        """Get a team member by name.
 
         Args:
-            member: Agent name or agent_id (as string or UUID)
+            member: Agent name
 
         Returns:
             ActorAddress if found, None otherwise

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -405,7 +405,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._current_team_members = active
         return active
 
-    def get_team_member(self, member: str) -> ActorAddress | None:
+    def get_team_member(self, name: str) -> ActorAddress | None:
         """Get a team member by name or agent_id.
 
         Args:
@@ -415,11 +415,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             ActorAddress if found, None otherwise
         """
         return next(
-            (
-                mbr
-                for mbr in self.get_team()
-                if mbr.name == str(member) or str(mbr.agent_id) == str(member)
-            ),
+            (mbr for mbr in self.get_team() if mbr.name == name),
             None,
         )
 


### PR DESCRIPTION
## Summary

Replace custom `init()` lifecycle method with pykka's built-in `on_start()` lifecycle hook for more idiomatic actor initialization.

## Key Changes

### Latest Commit: Lifecycle Refactoring (9637806)
- **Rename `Akgent.init()` → `on_start()`** to use pykka's actor lifecycle
- **Rename `Orchestrator.init()` → `on_start()`** for consistency
- **Remove manual `init()` calls** after actor creation in `spawn_child()` and `create_agent()`
- Pykka now automatically invokes `on_start()` after actor construction

### Previous Commit: Deferred Initialization (7e55099)
- Move `init()` call from `Akgent.__init__()` to post-creation
- Add public `orchestrator` property to `Akgent`
- Rename `get_team_member()` parameter from `member` to `name`

## Benefits
- ✅ More idiomatic pykka usage leveraging framework lifecycle
- ✅ Eliminates manual initialization step and potential timing issues
- ✅ Cleaner separation between construction and initialization
- ✅ Consistent with pykka best practices

## Related PRs

Cross-repo lifecycle changes:

| Package | PR | Status |
|---|---|---|
| **akgentic-core** | [#1](https://github.com/b12consulting/akgentic-core/pull/1) (this PR) | ✅ Ready |
| **akgentic-tool** | [#2](https://github.com/b12consulting/akgentic-tool/pull/2) | ✅ Ready |

### Merge Order
1. ✅ **akgentic-core** (this PR) - foundation changes
2. ✅ **akgentic-tool** - depends on core lifecycle changes
