### PR TITLE
fix: remove unused variable and resolve ruff lint violations

### DIFF
--- a/examples/06_agent_cards.py
+++ b/examples/06_agent_cards.py
@@ -28,7 +28,7 @@ from akgentic.core import (
 class ResearchAgent(Akgent):
     """Agent that performs research tasks."""
 
-    def on_start(self):
+    def on_start(self) -> None:
         """Initialize the research agent."""
         print(f"[{self.config.name}] Research agent initialized")
 
@@ -36,7 +36,7 @@ class ResearchAgent(Akgent):
 class WriterAgent(Akgent):
     """Agent that writes content."""
 
-    def on_start(self):
+    def on_start(self) -> None:
         """Initialize the writer agent."""
         print(f"[{self.config.name}] Writer agent initialized")
 
@@ -44,7 +44,7 @@ class WriterAgent(Akgent):
 class CoordinatorAgent(Akgent):
     """Agent that discovers and coordinates other agents."""
 
-    def on_start(self):
+    def on_start(self) -> None:
         """Initialize the coordinator agent."""
         print(f"[{self.config.name}] Coordinator initialized")
 
@@ -61,7 +61,7 @@ class CoordinatorAgent(Akgent):
             if card.routes_to:
                 print(f"    Routes to: {', '.join(card.routes_to)}")
             else:
-                print(f"    Routes to: (any role)")
+                print("    Routes to: (any role)")
 
         # Find specific profile
         print(f"\n[{self.config.name}] Looking for ResearchAgent profile...")

--- a/src/akgentic/core/agent_card.py
+++ b/src/akgentic/core/agent_card.py
@@ -52,7 +52,7 @@ class AgentCard(SerializableBaseModel):
     description: str
     skills: list[str]
     agent_class: str | type
-    config: BaseConfig
+    config: BaseConfig = BaseConfig()
     routes_to: list[str] = []
     metadata: dict[str, Any] = {}
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -40,7 +40,7 @@ class DerivedSampleMessage(SampleMessage):
 class SampleAgent(Akgent[BaseConfig, BaseState]):
     """Test agent with message handler."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.received_messages: list = []
         super().__init__(**kwargs)
 
@@ -53,7 +53,7 @@ class SampleAgent(Akgent[BaseConfig, BaseState]):
 class SuperSampleAgent(Akgent[BaseConfig, BaseState]):
     """Test agent that uses SUPER sentinel."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.handled_at_base = False
         super().__init__(**kwargs)
 
@@ -61,7 +61,7 @@ class SuperSampleAgent(Akgent[BaseConfig, BaseState]):
         """Decline to handle - return SUPER."""
         return self.SUPER
 
-    def receiveMsg_Message(self, msg: Message, sender: Any):
+    def receiveMsg_Message(self, msg: Message, sender: Any) -> str:
         """Base Message handler - catches fallthrough."""
         self.handled_at_base = True
         return "base_handler"
@@ -89,7 +89,7 @@ def cleanup_actors():
 class TestAgentInitialization:
     """Tests for agent lifecycle."""
 
-    def test_agent_starts_and_stops(self, agent_setup):
+    def test_agent_starts_and_stops(self, agent_setup) -> None:
         """Agent can be started and stopped cleanly."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(
@@ -104,7 +104,7 @@ class TestAgentInitialization:
         finally:
             ref.stop()
 
-    def test_agent_keyword_arg_initialization(self):
+    def test_agent_keyword_arg_initialization(self) -> None:
         """Agent can be initialized with explicit keyword arguments."""
         agent_id = uuid.uuid4()
         team_id = uuid.uuid4()
@@ -137,7 +137,7 @@ class TestAgentInitialization:
         finally:
             ref.stop()
 
-    def test_agent_keyword_args_with_defaults(self):
+    def test_agent_keyword_args_with_defaults(self) -> None:
         """Agent keyword args use defaults when not specified."""
         config = BaseConfig(name="test-agent")
 
@@ -156,7 +156,7 @@ class TestAgentInitialization:
         finally:
             ref.stop()
 
-    def test_agent_receives_uuid_and_config(self, agent_setup):
+    def test_agent_receives_uuid_and_config(self, agent_setup) -> None:
         """Agent initialization extracts args correctly."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(
@@ -174,7 +174,7 @@ class TestAgentInitialization:
         finally:
             ref.stop()
 
-    def test_agent_defaults_name_and_role(self, agent_setup):
+    def test_agent_defaults_name_and_role(self, agent_setup) -> None:
         """Agent sets default name and role if not provided."""
         agent_id, _, team_id = agent_setup
         config = BaseConfig()  # No name or role
@@ -196,15 +196,15 @@ class TestAgentInitialization:
         finally:
             ref.stop()
 
-    def test_init_hook_called(self, agent_setup):
+    def test_init_hook_called(self, agent_setup) -> None:
         """Agent on_start() hook is called during initialization."""
 
         class InitTestAgent(Akgent[BaseConfig, BaseState]):
-            def __init__(self, **kwargs):
+            def __init__(self, **kwargs) -> None:
                 self.init_called = False
                 super().__init__(**kwargs)
 
-            def on_start(self):
+            def on_start(self) -> None:
                 self.init_called = True
 
         agent_id, config, team_id = agent_setup
@@ -223,7 +223,7 @@ class TestAgentInitialization:
 class TestMessageDispatch:
     """Tests for receiveMsg_<Type> pattern."""
 
-    def test_message_handler_called(self, agent_setup):
+    def test_message_handler_called(self, agent_setup) -> None:
         """Message dispatch invokes correct handler."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -239,7 +239,7 @@ class TestMessageDispatch:
         finally:
             ref.stop()
 
-    def test_derived_message_uses_handler(self, agent_setup):
+    def test_derived_message_uses_handler(self, agent_setup) -> None:
         """Derived message types use parent handler via MRO."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -255,7 +255,7 @@ class TestMessageDispatch:
         finally:
             ref.stop()
 
-    def test_unhandled_message_logs_warning(self, agent_setup, caplog):
+    def test_unhandled_message_logs_warning(self, agent_setup, caplog) -> None:
         """Unhandled message type logs warning."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -276,7 +276,7 @@ class TestMessageDispatch:
 class TestSuperSentinel:
     """Tests for SUPER fallthrough behavior."""
 
-    def test_super_continues_mro_search(self, agent_setup):
+    def test_super_continues_mro_search(self, agent_setup) -> None:
         """Returning SUPER causes dispatcher to continue MRO walk."""
         agent_id, config, team_id = agent_setup
         ref = SuperSampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -296,7 +296,7 @@ class TestSuperSentinel:
 class TestChildActorCreation:
     """Tests for createActor and context propagation."""
 
-    def test_create_child_actor(self, agent_setup):
+    def test_create_child_actor(self, agent_setup) -> None:
         """Parent can create child actor."""
         agent_id, config, team_id = agent_setup
         config.squad_id = uuid.uuid4()
@@ -314,7 +314,7 @@ class TestChildActorCreation:
         finally:
             ref.stop()
 
-    def test_child_inherits_squad_id(self, agent_setup):
+    def test_child_inherits_squad_id(self, agent_setup) -> None:
         """Child actor inherits parent's squad_id if not specified."""
         agent_id, config, team_id = agent_setup
         parent_squad_id = uuid.uuid4()
@@ -334,7 +334,7 @@ class TestChildActorCreation:
         finally:
             ref.stop()
 
-    def test_child_overrides_squad_id(self, agent_setup):
+    def test_child_overrides_squad_id(self, agent_setup) -> None:
         """Child can override parent's squad_id."""
         agent_id, config, team_id = agent_setup
         parent_squad_id = uuid.uuid4()
@@ -359,7 +359,7 @@ class TestChildActorCreation:
 class TestStateManagement:
     """Tests for state_changed, update_state, init_state."""
 
-    def test_init_state_preserves_observer(self, agent_setup):
+    def test_init_state_preserves_observer(self, agent_setup) -> None:
         """init_state preserves observer reference."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -377,7 +377,7 @@ class TestStateManagement:
         finally:
             ref.stop()
 
-    def test_update_state_merges_updates(self, agent_setup):
+    def test_update_state_merges_updates(self, agent_setup) -> None:
         """update_state merges dictionary updates into state."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -397,7 +397,7 @@ class TestStateManagement:
 class TestStopBehavior:
     """Tests for stop and recursive cleanup."""
 
-    def test_stop_cleans_up_children(self, agent_setup):
+    def test_stop_cleans_up_children(self, agent_setup) -> None:
         """Stopping parent stops all children recursively."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -422,7 +422,7 @@ class TestStopBehavior:
             except Exception:
                 pass
 
-    def test_stop_recursively_message(self, agent_setup):
+    def test_stop_recursively_message(self, agent_setup) -> None:
         """StopRecursively message triggers recursive stop."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -442,7 +442,7 @@ class TestStopBehavior:
 class TestProxyHelpers:
     """Tests for proxy_tell and proxy_ask."""
 
-    def test_proxy_tell_fire_and_forget(self, agent_setup):
+    def test_proxy_tell_fire_and_forget(self, agent_setup) -> None:
         """proxy_tell creates fire-and-forget proxy."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -457,7 +457,7 @@ class TestProxyHelpers:
         finally:
             ref.stop()
 
-    def test_proxy_ask_blocking(self, agent_setup):
+    def test_proxy_ask_blocking(self, agent_setup) -> None:
         """proxy_ask creates blocking proxy."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -477,7 +477,7 @@ class TestProxyHelpers:
 class TestProxyWrapper:
     """Tests for ProxyWrapper functionality."""
 
-    def test_proxy_wrapper_ask_mode_resolves_futures(self, agent_setup):
+    def test_proxy_wrapper_ask_mode_resolves_futures(self, agent_setup) -> None:
         """Ask mode automatically resolves pykka futures."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -491,7 +491,7 @@ class TestProxyWrapper:
         finally:
             ref.stop()
 
-    def test_proxy_wrapper_tell_mode_returns_none(self, agent_setup):
+    def test_proxy_wrapper_tell_mode_returns_none(self, agent_setup) -> None:
         """Tell mode returns None without blocking."""
         agent_id, config, team_id = agent_setup
         ref = SampleAgent.start(agent_id=agent_id, config=config, team_id=team_id)
@@ -509,7 +509,7 @@ class TestProxyWrapper:
 class TestOrchestratorIntegration:
     """Tests for orchestrator notification integration."""
 
-    def test_notify_orchestrator_sends_start_message(self, agent_setup):
+    def test_notify_orchestrator_sends_start_message(self, agent_setup) -> None:
         """Agent notifies orchestrator on initialization."""
         agent_id, config, team_id = agent_setup
 
@@ -534,7 +534,7 @@ class TestOrchestratorIntegration:
         finally:
             ref.stop()
 
-    def test_send_notifies_orchestrator(self, agent_setup):
+    def test_send_notifies_orchestrator(self, agent_setup) -> None:
         """send() notifies orchestrator with SentMessage."""
         agent_id, config, team_id = agent_setup
 

--- a/tests/core/test_agent_card.py
+++ b/tests/core/test_agent_card.py
@@ -16,7 +16,7 @@ from akgentic.core import (
 class TestAgentCard:
     """Test AgentCard creation and serialization."""
 
-    def test_create_agent_card_with_config(self):
+    def test_create_agent_card_with_config(self) -> None:
         """AgentCard can store config."""
         config = BaseConfig(name="test", role="TestAgent")
         card = AgentCard(
@@ -33,7 +33,7 @@ class TestAgentCard:
         retrieved_config = card.get_config_copy()
         assert retrieved_config.name == "test"
 
-    def test_create_agent_card_with_dict_config(self):
+    def test_create_agent_card_with_dict_config(self) -> None:
         """AgentCard accepts dict config."""
         card = AgentCard(
             role="TestAgent",
@@ -47,7 +47,7 @@ class TestAgentCard:
         assert config.name == "test"
         assert config.role == "TestAgent"
 
-    def test_agent_class_accepts_string(self):
+    def test_agent_class_accepts_string(self) -> None:
         """AgentCard accepts agent_class as string."""
         card = AgentCard(
             role="TestAgent",
@@ -57,7 +57,7 @@ class TestAgentCard:
         )
         assert card.agent_class == "test.TestAgent"
 
-    def test_agent_class_accepts_type(self):
+    def test_agent_class_accepts_type(self) -> None:
         """AgentCard accepts agent_class as actual type."""
         card = AgentCard(
             role="TestAgent",
@@ -68,7 +68,7 @@ class TestAgentCard:
         assert card.agent_class == Akgent
         assert isinstance(card.agent_class, type)
 
-    def test_has_skill(self):
+    def test_has_skill(self) -> None:
         """AgentCard.has_skill() checks for skill presence."""
         card = AgentCard(
             role="TestAgent",
@@ -80,7 +80,7 @@ class TestAgentCard:
         assert card.has_skill("skill1") is True
         assert card.has_skill("skill3") is False
 
-    def test_metadata_extensibility(self):
+    def test_metadata_extensibility(self) -> None:
         """AgentCard supports custom metadata."""
         card = AgentCard(
             role="TestAgent",
@@ -93,7 +93,7 @@ class TestAgentCard:
         assert card.metadata["version"] == "1.0"
         assert card.metadata["author"] == "team-alpha"
 
-    def test_routes_to_unrestricted(self):
+    def test_routes_to_unrestricted(self) -> None:
         """AgentCard with empty routes_to allows routing to any role."""
         card = AgentCard(
             role="TestAgent",
@@ -106,7 +106,7 @@ class TestAgentCard:
         assert card.can_route_to("AnyRole") is True
         assert card.can_route_to("AnotherRole") is True
 
-    def test_routes_to_restricted(self):
+    def test_routes_to_restricted(self) -> None:
         """AgentCard with routes_to list restricts routing."""
         card = AgentCard(
             role="ResearchAgent",
@@ -120,7 +120,7 @@ class TestAgentCard:
         assert card.can_route_to("AnalystAgent") is True
         assert card.can_route_to("OtherAgent") is False
 
-    def test_routes_to_default_empty(self):
+    def test_routes_to_default_empty(self) -> None:
         """AgentCard defaults to no routing restrictions."""
         card = AgentCard(
             role="TestAgent",
@@ -133,7 +133,7 @@ class TestAgentCard:
         assert card.routes_to == []
         assert card.can_route_to("AnyRole") is True
 
-    def test_get_config_returns_independent_copies(self):
+    def test_get_config_returns_independent_copies(self) -> None:
         """get_config() returns independent copies to prevent shared state."""
         card = AgentCard(
             role="TestAgent",
@@ -164,7 +164,7 @@ class TestAgentCard:
 class TestGetAgentClass:
     """Tests for AgentCard.get_agent_class()."""
 
-    def test_returns_type_when_agent_class_is_type(self):
+    def test_returns_type_when_agent_class_is_type(self) -> None:
         """get_agent_class() returns the class directly when already a type."""
         card = AgentCard(
             role="TestAgent",
@@ -174,7 +174,7 @@ class TestGetAgentClass:
         )
         assert card.get_agent_class() is Akgent
 
-    def test_resolves_fully_qualified_string(self):
+    def test_resolves_fully_qualified_string(self) -> None:
         """get_agent_class() resolves a dotted string to the actual class."""
         card = AgentCard(
             role="TestAgent",
@@ -184,7 +184,7 @@ class TestGetAgentClass:
         )
         assert card.get_agent_class() is Akgent
 
-    def test_raises_value_error_for_empty_string(self):
+    def test_raises_value_error_for_empty_string(self) -> None:
         """get_agent_class() raises ValueError for empty agent_class string."""
         card = AgentCard(
             role="TestAgent",
@@ -195,7 +195,7 @@ class TestGetAgentClass:
         with pytest.raises(ValueError, match="fully qualified dotted path"):
             card.get_agent_class()
 
-    def test_raises_value_error_for_unqualified_name(self):
+    def test_raises_value_error_for_unqualified_name(self) -> None:
         """get_agent_class() raises ValueError for a bare class name with no dots."""
         card = AgentCard(
             role="TestAgent",
@@ -206,7 +206,7 @@ class TestGetAgentClass:
         with pytest.raises(ValueError, match="fully qualified dotted path"):
             card.get_agent_class()
 
-    def test_raises_import_error_for_missing_module(self):
+    def test_raises_import_error_for_missing_module(self) -> None:
         """get_agent_class() raises ImportError when the module doesn't exist."""
         card = AgentCard(
             role="TestAgent",
@@ -217,7 +217,7 @@ class TestGetAgentClass:
         with pytest.raises(ModuleNotFoundError):
             card.get_agent_class()
 
-    def test_raises_attribute_error_for_missing_class(self):
+    def test_raises_attribute_error_for_missing_class(self) -> None:
         """get_agent_class() raises AttributeError when the class isn't in the module."""
         card = AgentCard(
             role="TestAgent",
@@ -232,7 +232,7 @@ class TestGetAgentClass:
 class TestOrchestratorCatalog:
     """Test Orchestrator catalog management."""
 
-    def test_register_and_retrieve_agent_profile(self):
+    def test_register_and_retrieve_agent_profile(self) -> None:
         """Orchestrator can register and retrieve agent profiles."""
         system = ActorSystem()
         try:
@@ -261,7 +261,7 @@ class TestOrchestratorCatalog:
         finally:
             system.shutdown()
 
-    def test_get_agent_catalog(self):
+    def test_get_agent_catalog(self) -> None:
         """Orchestrator returns all registered profiles."""
         system = ActorSystem()
         try:
@@ -298,7 +298,7 @@ class TestOrchestratorCatalog:
         finally:
             system.shutdown()
 
-    def test_get_profiles_by_skill(self):
+    def test_get_profiles_by_skill(self) -> None:
         """Orchestrator can filter profiles by skill."""
         system = ActorSystem()
         try:
@@ -345,7 +345,7 @@ class TestOrchestratorCatalog:
         finally:
             system.shutdown()
 
-    def test_get_available_roles(self):
+    def test_get_available_roles(self) -> None:
         """Orchestrator returns list of available roles."""
         system = ActorSystem()
         try:
@@ -369,7 +369,7 @@ class TestOrchestratorCatalog:
         finally:
             system.shutdown()
 
-    def test_get_available_skills(self):
+    def test_get_available_skills(self) -> None:
         """Orchestrator returns unique list of all skills."""
         system = ActorSystem()
         try:
@@ -413,7 +413,7 @@ class SimpleAgent(Akgent):
 class TestAgentDiscovery:
     """Test agent-side discovery methods."""
 
-    def test_discover_catalog_from_agent(self):
+    def test_discover_catalog_from_agent(self) -> None:
         """Agent can discover catalog via orchestrator."""
         system = ActorSystem()
         try:
@@ -449,7 +449,7 @@ class TestAgentDiscovery:
         finally:
             system.shutdown()
 
-    def test_discover_profile_by_role(self):
+    def test_discover_profile_by_role(self) -> None:
         """Agent can discover specific profile by role."""
         system = ActorSystem()
         try:
@@ -483,7 +483,7 @@ class TestAgentDiscovery:
         finally:
             system.shutdown()
 
-    def test_find_agents_with_skill(self):
+    def test_find_agents_with_skill(self) -> None:
         """Agent can find profiles by skill."""
         system = ActorSystem()
         try:
@@ -526,7 +526,7 @@ class TestAgentDiscovery:
         finally:
             system.shutdown()
 
-    def test_discovery_without_orchestrator(self):
+    def test_discovery_without_orchestrator(self) -> None:
         """Discovery methods return empty when no orchestrator."""
         system = ActorSystem()
         try:
@@ -552,7 +552,7 @@ class TestAgentDiscovery:
         finally:
             system.shutdown()
 
-    def test_get_available_roles_from_agent(self):
+    def test_get_available_roles_from_agent(self) -> None:
         """Agent can get list of available roles from catalog."""
         system = ActorSystem()
         try:

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,6 +1,7 @@
 """Tests for Orchestrator agent."""
 
 from collections.abc import Generator
+from typing import Never
 
 import pykka
 import pytest
@@ -10,7 +11,6 @@ from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.orchestrator import Orchestrator
-from typing import Never
 
 
 @pytest.fixture(autouse=True)

--- a/tests/examples/test_example_dynamic_agents.py
+++ b/tests/examples/test_example_dynamic_agents.py
@@ -14,7 +14,7 @@ import sys
 import time
 from pathlib import Path
 
-from akgentic.core import ActorAddress, ActorSystem, Akgent, BaseConfig
+from akgentic.core import ActorSystem, Akgent, BaseConfig
 from akgentic.core.messages import Message
 
 

--- a/tests/examples/test_example_hello_world.py
+++ b/tests/examples/test_example_hello_world.py
@@ -18,7 +18,7 @@ from akgentic.core.messages import Message
 class TestHelloMessageDefinition:
     """Tests for HelloMessage class definition."""
 
-    def test_hello_message_can_be_imported(self):
+    def test_hello_message_can_be_imported(self) -> None:
         """HelloMessage class can be imported from example."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "01_hello_world.py"
         spec = importlib.util.spec_from_file_location("hello_world", example_path)
@@ -30,7 +30,7 @@ class TestHelloMessageDefinition:
         assert hasattr(module, "HelloMessage"), "HelloMessage not defined in example"
         assert issubclass(module.HelloMessage, Message), "HelloMessage must extend Message"
 
-    def test_hello_message_has_greeting_field(self):
+    def test_hello_message_has_greeting_field(self) -> None:
         """HelloMessage has greeting string field."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "01_hello_world.py"
         spec = importlib.util.spec_from_file_location("hello_world", example_path)
@@ -46,7 +46,7 @@ class TestHelloMessageDefinition:
 class TestReceiverAgentHandler:
     """Tests for ReceiverAgent message handling."""
 
-    def test_receiver_agent_handles_hello_message(self, capsys):
+    def test_receiver_agent_handles_hello_message(self, capsys) -> None:
         """ReceiverAgent.receiveMsg_HelloMessage prints greeting."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "01_hello_world.py"
         spec = importlib.util.spec_from_file_location("hello_world", example_path)
@@ -82,7 +82,7 @@ class TestReceiverAgentHandler:
 class TestGreeterAgentSender:
     """Tests for GreeterAgent message sending."""
 
-    def test_greeter_agent_can_be_created(self):
+    def test_greeter_agent_can_be_created(self) -> None:
         """GreeterAgent can be instantiated."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "01_hello_world.py"
         spec = importlib.util.spec_from_file_location("hello_world", example_path)
@@ -98,7 +98,7 @@ class TestGreeterAgentSender:
 class TestEndToEndExecution:
     """Tests for complete example execution."""
 
-    def test_example_runs_without_exceptions(self, capsys):
+    def test_example_runs_without_exceptions(self, capsys) -> None:
         """Example runs end-to-end without errors."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "01_hello_world.py"
 
@@ -120,7 +120,7 @@ class TestEndToEndExecution:
         assert "[Hello World]" in result.stdout or "[ReceiverAgent]" in result.stdout
         assert "Hello" in result.stdout or "greeting" in result.stdout.lower()
 
-    def test_example_completes_within_timeout(self):
+    def test_example_completes_within_timeout(self) -> None:
         """Example completes execution within 5 seconds."""
         import subprocess
         import time

--- a/tests/examples/test_example_multi_agent.py
+++ b/tests/examples/test_example_multi_agent.py
@@ -27,7 +27,7 @@ from akgentic.core.messages import Message
 class TestMessageTypesDefinition:
     """Tests for message type definitions."""
 
-    def test_task_request_message_definition(self):
+    def test_task_request_message_definition(self) -> None:
         """TaskRequest message has topic and requester_id fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -43,7 +43,7 @@ class TestMessageTypesDefinition:
         assert msg.topic == "test topic"
         assert msg.requester_id == "test-requester"
 
-    def test_research_result_message_definition(self):
+    def test_research_result_message_definition(self) -> None:
         """ResearchResult message has topic, key_points, and summary fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -64,7 +64,7 @@ class TestMessageTypesDefinition:
         assert msg.key_points == ["point1", "point2"]
         assert msg.summary == "test summary"
 
-    def test_draft_content_message_definition(self):
+    def test_draft_content_message_definition(self) -> None:
         """DraftContent message has topic, content, and word_count fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -81,7 +81,7 @@ class TestMessageTypesDefinition:
         assert msg.content == "test content"
         assert msg.word_count == 2
 
-    def test_review_request_message_definition(self):
+    def test_review_request_message_definition(self) -> None:
         """ReviewRequest message has draft and reviewer_notes fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -98,7 +98,7 @@ class TestMessageTypesDefinition:
         assert msg.draft.topic == "test"
         assert msg.reviewer_notes == "Please review"
 
-    def test_approval_response_message_definition(self):
+    def test_approval_response_message_definition(self) -> None:
         """ApprovalResponse message has approved, feedback, and draft_id fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -123,7 +123,7 @@ class TestMessageTypesDefinition:
 class TestStateTypesDefinition:
     """Tests for state type definitions."""
 
-    def test_coordinator_state_definition(self):
+    def test_coordinator_state_definition(self) -> None:
         """CoordinatorState extends BaseState with required fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -142,7 +142,7 @@ class TestStateTypesDefinition:
         assert hasattr(state, "task_status"), "Missing task_status field"
         assert hasattr(state, "workflow_stage"), "Missing workflow_stage field"
 
-    def test_specialist_state_definition(self):
+    def test_specialist_state_definition(self) -> None:
         """SpecialistState extends BaseState with required fields."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -165,7 +165,7 @@ class TestStateTypesDefinition:
 class TestAgentDefinitions:
     """Tests for agent class definitions."""
 
-    def test_research_agent_definition(self):
+    def test_research_agent_definition(self) -> None:
         """ResearchAgent is properly defined agent."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -177,7 +177,7 @@ class TestAgentDefinitions:
         assert hasattr(module, "ResearchAgent"), "ResearchAgent not defined"
         assert issubclass(module.ResearchAgent, Akgent), "ResearchAgent must extend Akgent"
 
-    def test_writer_agent_definition(self):
+    def test_writer_agent_definition(self) -> None:
         """WriterAgent is properly defined agent."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -189,7 +189,7 @@ class TestAgentDefinitions:
         assert hasattr(module, "WriterAgent"), "WriterAgent not defined"
         assert issubclass(module.WriterAgent, Akgent), "WriterAgent must extend Akgent"
 
-    def test_coordinator_agent_definition(self):
+    def test_coordinator_agent_definition(self) -> None:
         """CoordinatorAgent is properly defined agent."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -205,7 +205,7 @@ class TestAgentDefinitions:
 class TestUserProxyIntegration:
     """Tests for UserProxy human-in-the-loop integration."""
 
-    def test_simulated_user_proxy_definition(self):
+    def test_simulated_user_proxy_definition(self) -> None:
         """SimulatedUserProxy is defined and extends UserProxy."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -221,7 +221,7 @@ class TestUserProxyIntegration:
             "SimulatedUserProxy must extend UserProxy"
         )
 
-    def test_user_proxy_handles_review_request(self):
+    def test_user_proxy_handles_review_request(self) -> None:
         """SimulatedUserProxy handles ReviewRequest messages."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -238,7 +238,7 @@ class TestUserProxyIntegration:
 class TestSimpleLoggerSubscriber:
     """Tests for SimpleLogger implementing EventSubscriber."""
 
-    def test_simple_logger_definition(self):
+    def test_simple_logger_definition(self) -> None:
         """SimpleLogger is defined and implements EventSubscriber."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -247,7 +247,6 @@ class TestSimpleLoggerSubscriber:
         assert spec.loader is not None, "No loader for example module"
         spec.loader.exec_module(module)
 
-        from akgentic.core import EventSubscriber
 
         assert hasattr(module, "SimpleLogger"), "SimpleLogger not defined"
         # Check that it has required methods
@@ -259,7 +258,7 @@ class TestSimpleLoggerSubscriber:
 class TestMessageRoutingChain:
     """Tests for complete message routing through workflow."""
 
-    def test_task_request_routes_to_research_agent(self, capsys):
+    def test_task_request_routes_to_research_agent(self, capsys) -> None:
         """TaskRequest is routed from CoordinatorAgent to ResearchAgent."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -313,7 +312,7 @@ class TestMessageRoutingChain:
         finally:
             system.shutdown(timeout=5)
 
-    def test_research_result_routes_to_writer_agent(self, capsys):
+    def test_research_result_routes_to_writer_agent(self, capsys) -> None:
         """ResearchResult from ResearchAgent is routed to WriterAgent."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -364,7 +363,7 @@ class TestMessageRoutingChain:
         finally:
             system.shutdown(timeout=5)
 
-    def test_draft_content_routes_to_user_proxy(self, capsys):
+    def test_draft_content_routes_to_user_proxy(self, capsys) -> None:
         """DraftContent from WriterAgent is routed to UserProxy for review."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -420,7 +419,7 @@ class TestMessageRoutingChain:
 class TestOrchestratorTracking:
     """Tests for Orchestrator telemetry tracking."""
 
-    def test_orchestrator_tracks_multiple_messages(self):
+    def test_orchestrator_tracks_multiple_messages(self) -> None:
         """Orchestrator tracks 12+ messages in multi-agent workflow."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -473,7 +472,7 @@ class TestOrchestratorTracking:
         finally:
             system.shutdown(timeout=5)
 
-    def test_orchestrator_tracks_team_composition(self):
+    def test_orchestrator_tracks_team_composition(self) -> None:
         """Orchestrator.get_team() returns all 4 agents."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -517,7 +516,7 @@ class TestOrchestratorTracking:
         finally:
             system.shutdown(timeout=5)
 
-    def test_orchestrator_tracks_agent_states(self):
+    def test_orchestrator_tracks_agent_states(self) -> None:
         """Orchestrator.get_states() tracks agent state snapshots."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
         spec = importlib.util.spec_from_file_location("multi_agent", example_path)
@@ -574,7 +573,7 @@ class TestOrchestratorTracking:
 class TestEndToEndExecution:
     """Tests for complete example execution."""
 
-    def test_example_runs_without_exceptions(self):
+    def test_example_runs_without_exceptions(self) -> None:
         """Example runs end-to-end without errors."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
 
@@ -588,7 +587,7 @@ class TestEndToEndExecution:
 
         assert result.returncode == 0, f"Example failed with stderr: {result.stderr}"
 
-    def test_example_demonstrates_complete_workflow(self):
+    def test_example_demonstrates_complete_workflow(self) -> None:
         """Example output shows complete workflow progression."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
 
@@ -613,7 +612,7 @@ class TestEndToEndExecution:
         assert "[UserProxy] Human approved" in output, "Should show human approval"
         assert "[CoordinatorAgent] Task complete" in output, "Should show task completion"
 
-    def test_example_shows_orchestrator_summary(self):
+    def test_example_shows_orchestrator_summary(self) -> None:
         """Example output shows Orchestrator telemetry summary."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
 
@@ -635,7 +634,7 @@ class TestEndToEndExecution:
         assert "State snapshots:" in output, "Should show state snapshot count"
         assert "===========================" in output, "Should show summary footer"
 
-    def test_example_shows_team_assembly(self):
+    def test_example_shows_team_assembly(self) -> None:
         """Example output shows team assembly message."""
         example_path = Path(__file__).parent.parent.parent / "examples" / "05_multi_agent.py"
 
@@ -657,7 +656,7 @@ class TestEndToEndExecution:
         assert "WriterAgent" in output, "Should mention WriterAgent"
         assert "UserProxy" in output, "Should mention UserProxy"
 
-    def test_example_completes_within_timeout(self):
+    def test_example_completes_within_timeout(self) -> None:
         """Example completes execution within 15 seconds."""
         import time
 

--- a/tests/examples/test_example_request_response.py
+++ b/tests/examples/test_example_request_response.py
@@ -122,7 +122,7 @@ class TestCalculatorAgentHandler:
             )
 
             # Create a dummy client to receive responses
-            client_addr = system.createActor(
+            system.createActor(
                 module.ClientAgent,
                 config=BaseConfig(name="test-client", role="Client"),
             )
@@ -158,7 +158,7 @@ class TestCalculatorAgentHandler:
             )
 
             # Create a dummy client to receive responses
-            client_addr = system.createActor(
+            system.createActor(
                 module.ClientAgent,
                 config=BaseConfig(name="test-client", role="Client"),
             )

--- a/tests/test_epic3_integration.py
+++ b/tests/test_epic3_integration.py
@@ -131,7 +131,6 @@ class TestOrchestratorTimerIntegration:
             ProcessedMessage(message_id=uuid.uuid4()), sender_addr
         ).get()
         assert timer.task_count == 0
-        timer_after_cycle1 = timer._timer
 
         # Cycle 2 — new message arrives, timer cancels again
         orch.receiveMsg_ReceivedMessage(ReceivedMessage(message_id=uuid.uuid4()), sender_addr).get()

--- a/tests/test_timer_integration.py
+++ b/tests/test_timer_integration.py
@@ -131,7 +131,6 @@ class TestOrchestratorTimerIntegration:
             ProcessedMessage(message_id=uuid.uuid4()), sender_addr
         ).get()
         assert timer.task_count == 0
-        timer_after_cycle1 = timer._timer
 
         # Cycle 2 — new message arrives, timer cancels again
         orch.receiveMsg_ReceivedMessage(ReceivedMessage(message_id=uuid.uuid4()), sender_addr).get()


### PR DESCRIPTION
## Summary
- Remove unused `timer_after_cycle1` variable in `test_epic3_integration.py` and `test_timer_integration.py`
- Make `AgentCard.config` optional with `BaseConfig()` default
- Add return type annotations across tests and examples (ANN rule)
- Remove unused imports: `ActorAddress`, `EventSubscriber`, `client_addr` (F401/F841)
- Fix f-string without placeholder and import ordering

Closes #3