### PR TITLE
feat: make ActorAddress.team_id non-optional

### DIFF
--- a/src/akgentic/core/actor_address.py
+++ b/src/akgentic/core/actor_address.py
@@ -79,11 +79,11 @@ class ActorAddress(ABC):
 
     @property
     @abstractmethod
-    def team_id(self) -> uuid.UUID | None:
+    def team_id(self) -> uuid.UUID:
         """Team identifier from configuration.
 
         Returns:
-            UUID of the team this agent belongs to, or None if not set.
+            UUID of the team this agent belongs to.
         """
         ...
 


### PR DESCRIPTION
## Summary

- Remove `Optional` from `ActorAddress.team_id` abstract property return type (`uuid.UUID | None` → `uuid.UUID`)
- Aligns the abstract interface with the auto-generation behavior introduced in #5 — `team_id` is now always assigned a `uuid4()` by `ActorSystem.createActor`

Relates to #5