### PR TITLE
Add Orchestrator.restore_message() and end_restoration()

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -370,14 +370,15 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
     def restore_message(self, message: Message) -> None:
         """Replay a single persisted event during team restoration.
 
-        Dispatches the message to all subscribers via ``_notify_subscribers``
-        without going through the normal ``receiveMsg_*`` dispatch. This
-        allows subscribers (e.g. PersistenceSubscriber in restoring mode)
-        and agents reconstructing LLM context to observe the replayed event.
+        Appends the message to ``self.messages`` so that ``get_team()`` and
+        other history-based queries work correctly after restore, then
+        dispatches to all subscribers via ``_notify_subscribers``.
 
         Args:
             message: The persisted message to replay.
         """
+        self.messages.append(message)
+        self._current_team_members = None  # Invalidate cache
         self._notify_subscribers("on_message", message)
 
     def end_restoration(self) -> None:

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -367,6 +367,28 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         """
         self._notify_subscribers("on_message", message)
 
+    def restore_message(self, message: Message) -> None:
+        """Replay a single persisted event during team restoration.
+
+        Dispatches the message to all subscribers via ``_notify_subscribers``
+        without going through the normal ``receiveMsg_*`` dispatch. This
+        allows subscribers (e.g. PersistenceSubscriber in restoring mode)
+        and agents reconstructing LLM context to observe the replayed event.
+
+        Args:
+            message: The persisted message to replay.
+        """
+        self._notify_subscribers("on_message", message)
+
+    def end_restoration(self) -> None:
+        """Signal that restoration replay is complete.
+
+        Sets ``_restoring`` to ``False`` so the orchestrator resumes normal
+        operation (e.g. recording telemetry, processing live messages).
+        """
+        self._restoring = False
+        logger.info("Orchestrator restoration complete, resuming normal operation")
+
     def get_team(self) -> list[ActorAddress]:
         """Get list of active agents (excludes Orchestrator role).
 

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -10,7 +10,8 @@ from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
-from akgentic.core.orchestrator import Orchestrator
+from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 
 
 @pytest.fixture(autouse=True)
@@ -246,5 +247,86 @@ class TestIntegration:
         # Orchestrator records its own StartMessage
         assert len(messages) == 1
         assert isinstance(messages[0], StartMessage)
+
+        system.shutdown()
+
+
+class RecordingSubscriber:
+    """Subscriber that records on_message calls for restore tests."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+        self.stopped: bool = False
+
+    def on_message(self, msg: Message) -> None:
+        """Record received message."""
+        self.messages.append(msg)
+
+    def on_stop(self) -> None:
+        """Record stop."""
+        self.stopped = True
+
+
+class TestRestoreMessage:
+    """Tests for Orchestrator.restore_message and end_restoration."""
+
+    def test_restore_message_dispatches_to_subscribers(self) -> None:
+        """restore_message notifies subscribers via on_message."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub)
+
+        msg = UserMessage(content="replayed message")
+        orch_proxy.restore_message(msg)
+
+        assert len(sub.messages) == 1
+        assert sub.messages[0] is msg
+
+        system.shutdown()
+
+    def test_restore_message_dispatches_multiple(self) -> None:
+        """restore_message dispatches to all registered subscribers."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        sub1 = RecordingSubscriber()
+        sub2 = RecordingSubscriber()
+        orch_proxy.subscribe(sub1)
+        orch_proxy.subscribe(sub2)
+
+        msg = UserMessage(content="test")
+        orch_proxy.restore_message(msg)
+
+        assert len(sub1.messages) == 1
+        assert len(sub2.messages) == 1
+
+        system.shutdown()
+
+    def test_end_restoration_toggles_restoring_flag(self) -> None:
+        """end_restoration sets _restoring to False."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+            restoring=True,
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        orch_proxy.end_restoration()
+
+        # After end_restoration, _restoring should be False
+        # We verify indirectly: the orchestrator is alive and functional
+        team = orch_proxy.get_team()
+        assert team == []
 
         system.shutdown()


### PR DESCRIPTION
## Summary

- Add `restore_message()` method to Orchestrator for replaying persisted events during team restoration. Appends to message history and notifies subscribers.
- Add `end_restoration()` method to toggle `_restoring` flag back to False after replay completes.
- Code review fix: `restore_message()` now appends to `self.messages` so that `get_team()` works correctly after restore (was only dispatching to subscribers).
- 3 new tests in `test_orchestrator.py`

Relates to b12consulting/akgentic-team#21