### PR TITLE
test: update test suite for pykka 4.4.2 weakref API (story 6.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0.0",
-    "pykka>=4.0.0",
+    "pykka>=4.4.2",
 ]
 
 [project.optional-dependencies]

--- a/src/akgentic/core/actor_address.py
+++ b/src/akgentic/core/actor_address.py
@@ -79,11 +79,11 @@ class ActorAddress(ABC):
 
     @property
     @abstractmethod
-    def team_id(self) -> uuid.UUID:
+    def team_id(self) -> uuid.UUID | None:
         """Team identifier from configuration.
 
         Returns:
-            UUID of the team this agent belongs to.
+            UUID of the team this agent belongs to, or None if not set.
         """
         ...
 

--- a/src/akgentic/core/actor_address_impl.py
+++ b/src/akgentic/core/actor_address_impl.py
@@ -30,9 +30,9 @@ class ActorAddressImpl(ActorAddress):
     instance. Used for local in-memory actor communication.
 
     Note:
-        This implementation accesses Pykka internal attributes (_actor_ref._actor)
-        which is an implementation detail. This is acceptable per v1 patterns
-        but should be noted as potentially fragile across Pykka versions.
+        This implementation accesses the Pykka 4.4.2+ weakref API
+        (_actor_ref._actor_weakref) to dereference the underlying actor.
+        Direct property access on a GC'd actor raises RuntimeError.
 
     Args:
         actor_ref: The Pykka ActorRef to wrap.
@@ -52,6 +52,20 @@ class ActorAddressImpl(ActorAddress):
         """
         self._actor_ref = actor_ref
 
+    def _resolve_actor(self) -> Any:
+        """Dereference the weak reference to the underlying actor.
+
+        Returns:
+            The live actor instance.
+
+        Raises:
+            RuntimeError: If the actor has been garbage collected.
+        """
+        actor = self._actor_ref._actor_weakref()
+        if actor is None:
+            raise RuntimeError(f"Actor {self._actor_ref.actor_urn} has been garbage collected")
+        return actor
+
     @property
     def agent_id(self) -> uuid.UUID:
         """Unique identifier from the underlying actor.
@@ -59,7 +73,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             UUID from the actor's agent_id attribute.
         """
-        return self._actor_ref._actor.agent_id  # type: ignore[no-any-return]
+        return self._resolve_actor().agent_id  # type: ignore[no-any-return]
 
     @property
     def name(self) -> str:
@@ -68,7 +82,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             Name string from config, or string representation of actor_ref as fallback.
         """
-        actor = self._actor_ref._actor
+        actor = self._resolve_actor()
         config = getattr(actor, "config", None)
         if config is not None:
             return config.name  # type: ignore[no-any-return]
@@ -81,7 +95,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             Role string from config, or class name as fallback.
         """
-        actor = self._actor_ref._actor
+        actor = self._resolve_actor()
         config = getattr(actor, "config", None)
         if config is not None:
             return config.role  # type: ignore[no-any-return]
@@ -94,8 +108,8 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             UUID from _team_id, or None if not available.
         """
-        actor = self._actor_ref._actor
-        return getattr(actor, "_team_id", None)  # type: ignore[no-any-return]
+        actor = self._resolve_actor()
+        return getattr(actor, "_team_id", None)
 
     @property
     def squad_id(self) -> uuid.UUID | None:
@@ -104,7 +118,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             UUID from config.squad_id, or None if not available.
         """
-        actor = self._actor_ref._actor
+        actor = self._resolve_actor()
         config = getattr(actor, "config", None)
         if config is not None:
             return config.squad_id  # type: ignore[no-any-return]
@@ -138,7 +152,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             True if the actor has a receiveMsg_UserMessage method.
         """
-        actor = self._actor_ref._actor
+        actor = self._resolve_actor()
         accept_method = getattr(actor, "receiveMsg_UserMessage", None)
         return callable(accept_method)
 
@@ -151,7 +165,7 @@ class ActorAddressImpl(ActorAddress):
         Returns:
             ActorAddressDict with all actor metadata.
         """
-        agent_type = self._actor_ref._actor.__class__
+        agent_type = self._resolve_actor().__class__
         return {
             "__actor_address__": True,
             "__actor_type__": f"{agent_type.__module__}.{agent_type.__name__}",

--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -126,7 +126,7 @@ class ExecutionContext:
         recipient = cast(ActorAddressImpl, actor)
         if isinstance(message, Message):
             message.sender = ActorAddressImpl(self.listener_ref)
-            message.team_id = getattr(recipient._actor_ref._actor, "_team_id", None)
+            message.team_id = recipient.team_id
 
         recipient._actor_ref.tell(message)
 
@@ -144,7 +144,7 @@ class ExecutionContext:
         recipient = cast(ActorAddressImpl, actor)
         if isinstance(message, Message):
             message.sender = ActorAddressImpl(self.listener_ref)
-            message.team_id = getattr(recipient._actor_ref._actor, "_team_id", None)
+            message.team_id = recipient.team_id
 
         return recipient._actor_ref.ask(message, timeout=timeout)
 
@@ -207,14 +207,14 @@ class ActorSystem(ExecutionContext):
         Returns:
             The actor address if found, None otherwise.
         """
-        return next(
-            (
-                ActorAddressImpl(actor)
-                for actor in self.ActorRegistry.get_all()
-                if str(actor._actor.agent_id) == str(agent.agent_id)
-            ),
-            None,
-        )
+        for actor in self.ActorRegistry.get_all():
+            underlying = actor._actor_weakref()
+            if underlying is None:
+                # Actor has been garbage collected — skip silently
+                continue
+            if str(underlying.agent_id) == str(agent.agent_id):
+                return ActorAddressImpl(actor)
+        return None
 
     def stat(self) -> list[Statistics]:
         """Get system statistics including actor counts.

--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -244,7 +244,10 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
 
         ## set default name and role if not provided
         self.config.name = self.config.name or str(self._actor_ref)
-        self.config.role = self.config.role or self._actor_ref._actor.__class__.__name__
+        _underlying = self._actor_ref._actor_weakref()
+        self.config.role = self.config.role or (
+            _underlying.__class__.__name__ if _underlying is not None else ""
+        )
 
         if self._orchestrator is not None:
             from akgentic.core.orchestrator import Orchestrator

--- a/tests/core/test_actor_address.py
+++ b/tests/core/test_actor_address.py
@@ -137,7 +137,7 @@ class TestActorAddressImpl:
         # Add receiveMsg_UserMessage method for handle_user_message check
         actor.receiveMsg_UserMessage = MagicMock()
         # Set __class__ for serialize test
-        actor.__class__ = type(  # type: ignore
+        actor.__class__ = type(
             "MockAgent", (), {"__module__": "test.agents", "__name__": "MockAgent"}
         )
 

--- a/tests/core/test_actor_address.py
+++ b/tests/core/test_actor_address.py
@@ -113,14 +113,14 @@ class TestActorAddressImpl:
 
     @pytest.fixture
     def mock_actor_ref(self) -> MagicMock:
-        """Create mock Pykka ActorRef with actor matching v1 structure.
+        """Create mock Pykka ActorRef with actor matching pykka 4.4.2 weakref API.
 
         Accesses properties via:
-        - agent_id: _actor.agent_id
-        - name: _actor.config.name (with fallback)
-        - role: _actor.config.role (with fallback)
-        - team_id: _actor._team_id (flat attribute, not via _config)
-        - squad_id: _actor.config.squad_id (from user config)
+        - agent_id: _actor_weakref().agent_id
+        - name: _actor_weakref().config.name (with fallback)
+        - role: _actor_weakref().config.role (with fallback)
+        - team_id: _actor_weakref()._team_id (flat attribute, not via _config)
+        - squad_id: _actor_weakref().config.squad_id (from user config)
         - handle_user_message: checks for receiveMsg_UserMessage method
         """
         # Create config object (user config)
@@ -142,7 +142,8 @@ class TestActorAddressImpl:
         )
 
         actor_ref = MagicMock()
-        actor_ref._actor = actor
+        # pykka 4.4.2+: _actor_weakref() returns the actor (callable, not attribute)
+        actor_ref._actor_weakref = lambda: actor
         actor_ref.is_alive.return_value = True
         actor_ref.proxy.return_value = MagicMock()
         return actor_ref
@@ -151,13 +152,14 @@ class TestActorAddressImpl:
         """All properties should come from the underlying actor via config objects."""
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
+        actor = mock_actor_ref._actor_weakref()
         impl = ActorAddressImpl(mock_actor_ref)
-        assert impl.agent_id == mock_actor_ref._actor.agent_id
-        assert impl.name == mock_actor_ref._actor.config.name
-        assert impl.role == mock_actor_ref._actor.config.role
-        assert impl.team_id == mock_actor_ref._actor._team_id
-        assert impl.squad_id == mock_actor_ref._actor.config.squad_id
-        # V1 checks for receiveMsg_UserMessage method existence
+        assert impl.agent_id == actor.agent_id
+        assert impl.name == actor.config.name
+        assert impl.role == actor.config.role
+        assert impl.team_id == actor._team_id
+        assert impl.squad_id == actor.config.squad_id
+        # pykka 4.4.2+: checks for receiveMsg_UserMessage method existence
         assert impl.handle_user_message() is True
 
     def test_team_id_reads_flat_attribute(self, mock_actor_ref: MagicMock) -> None:
@@ -165,7 +167,8 @@ class TestActorAddressImpl:
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
         expected = uuid.UUID("87654321-4321-8765-4321-876543218765")
-        mock_actor_ref._actor._team_id = expected
+        actor = mock_actor_ref._actor_weakref()
+        actor._team_id = expected
 
         impl = ActorAddressImpl(mock_actor_ref)
         assert impl.team_id == expected
@@ -175,7 +178,8 @@ class TestActorAddressImpl:
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
         # spec=object prevents MagicMock from auto-creating _team_id
-        mock_actor_ref._actor = MagicMock(spec=["agent_id", "config"])
+        limited_actor = MagicMock(spec=["agent_id", "config"])
+        mock_actor_ref._actor_weakref = lambda: limited_actor
 
         impl = ActorAddressImpl(mock_actor_ref)
         assert impl.team_id is None
@@ -193,14 +197,27 @@ class TestActorAddressImpl:
         """serialize should produce correct ActorAddressDict with actual agent class."""
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
+        actor = mock_actor_ref._actor_weakref()
         impl = ActorAddressImpl(mock_actor_ref)
         serialized = impl.serialize()
 
         assert serialized["__actor_address__"] is True
-        # V1 serializes the actual agent class, not ActorAddressImpl
+        # pykka 4.4.2+: serializes the actual agent class, not ActorAddressImpl
         assert serialized["__actor_type__"] == "test.agents.MockAgent"
-        assert serialized["agent_id"] == str(mock_actor_ref._actor.agent_id)
-        assert serialized["name"] == mock_actor_ref._actor.config.name
+        assert serialized["agent_id"] == str(actor.agent_id)
+        assert serialized["name"] == actor.config.name
+
+    def test_resolve_actor_raises_on_gc(self, mock_actor_ref: MagicMock) -> None:
+        """_resolve_actor should raise RuntimeError when weakref returns None (actor GC'd)."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+
+        # Simulate GC'd actor: weakref returns None
+        mock_actor_ref._actor_weakref = lambda: None
+        mock_actor_ref.actor_urn = "urn:mock:gc-actor"
+
+        impl = ActorAddressImpl(mock_actor_ref)
+        with pytest.raises(RuntimeError, match="has been garbage collected"):
+            _ = impl.agent_id
 
     def test_equality_and_hashing(self, mock_actor_ref: MagicMock) -> None:
         """Equality and hash should be based on agent_id."""

--- a/tests/core/test_actor_address.py
+++ b/tests/core/test_actor_address.py
@@ -193,6 +193,19 @@ class TestActorAddressImpl:
         mock_actor_ref.is_alive.return_value = False
         assert impl.is_alive() is False
 
+    def test_handle_user_message_returns_false_when_no_receive_method(
+        self, mock_actor_ref: MagicMock
+    ) -> None:
+        """handle_user_message should return False when receiveMsg_UserMessage is absent."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+
+        # Use spec to prevent MagicMock from auto-creating receiveMsg_UserMessage
+        limited_actor = MagicMock(spec=["agent_id", "config"])
+        mock_actor_ref._actor_weakref = lambda: limited_actor
+
+        impl = ActorAddressImpl(mock_actor_ref)
+        assert impl.handle_user_message() is False
+
     def test_serialize_produces_correct_dict(self, mock_actor_ref: MagicMock) -> None:
         """serialize should produce correct ActorAddressDict with actual agent class."""
         from akgentic.core.actor_address_impl import ActorAddressImpl
@@ -206,9 +219,13 @@ class TestActorAddressImpl:
         assert serialized["__actor_type__"] == "test.agents.MockAgent"
         assert serialized["agent_id"] == str(actor.agent_id)
         assert serialized["name"] == actor.config.name
+        assert serialized["role"] == actor.config.role
+        assert serialized["team_id"] == str(actor._team_id)
+        assert serialized["squad_id"] == str(actor.config.squad_id)
+        assert serialized["user_message"] is True
 
     def test_resolve_actor_raises_on_gc(self, mock_actor_ref: MagicMock) -> None:
-        """_resolve_actor should raise RuntimeError when weakref returns None (actor GC'd)."""
+        """_resolve_actor raises RuntimeError containing the actor URN when weakref returns None."""
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
         # Simulate GC'd actor: weakref returns None
@@ -216,7 +233,7 @@ class TestActorAddressImpl:
         mock_actor_ref.actor_urn = "urn:mock:gc-actor"
 
         impl = ActorAddressImpl(mock_actor_ref)
-        with pytest.raises(RuntimeError, match="has been garbage collected"):
+        with pytest.raises(RuntimeError, match="urn:mock:gc-actor"):
             _ = impl.agent_id
 
     def test_equality_and_hashing(self, mock_actor_ref: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- Replaces `mock_actor_ref._actor = mock_actor` with `mock_actor_ref._actor_weakref = lambda: mock_actor` throughout `TestActorAddressImpl`, aligning tests with the pykka 4.4.2+ weakref API introduced in story 6.1.
- Adds `test_resolve_actor_raises_on_gc`: verifies `_resolve_actor()` raises `RuntimeError` containing the actor URN when the weakref returns `None` (AC3).
- Code review fixes: URN assertion in GC guard test (AC3 compliance), complete serialize dict assertions, and new `handle_user_message() -> False` edge case test.

## Quality Gates

- 400/400 tests pass (full suite, no regressions)
- mypy: zero errors on test file
- ruff: clean

## Dependency

**This PR depends on PR #17** merging first. This branch is rebased on the 6.1 branch - the _resolve_actor() helper from 6.1 is required at runtime.

Closes #18