### PR TITLE
fix: replace asdict with field iteration and TypeAdapter for dataclass serialization

### DIFF
--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -590,7 +590,7 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
         self.state = state
         self.notify_state_change(self.state)
 
-    def init_llm_context(self, context: list[Any]) -> None:
+    def init_llm_context(self, context: list[Message]) -> None:
         """Restore LLM conversation context after team resume.
 
         No-op in the base class. Overridden by LLM-capable agents

--- a/src/akgentic/core/utils/deserializer.py
+++ b/src/akgentic/core/utils/deserializer.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import base64
 import uuid
 from abc import ABC, abstractmethod
+from dataclasses import is_dataclass
 from importlib import import_module
 from typing import Any, TypedDict, cast
+
+from pydantic import PydanticUserError, TypeAdapter
 
 
 class ActorAddressDict(TypedDict):
@@ -81,6 +84,23 @@ def import_class(class_path: str) -> type[Any]:
     return getattr(module, class_name)  # type: ignore[no-any-return]
 
 
+_type_adapter_cache: dict[type[Any], TypeAdapter[Any] | None] = {}
+
+def _get_type_adapter(cls: type[Any]) -> TypeAdapter[Any] | None:
+    """Return a cached TypeAdapter for *cls*, or None if the type is not fully defined."""
+    try:
+        return _type_adapter_cache[cls]
+    except KeyError:
+        try:
+            ta: TypeAdapter[Any] | None = TypeAdapter(cls)
+        except Exception:
+            # TypeAdapter fails when annotations are unresolved
+            # (e.g. TYPE_CHECKING imports with `from __future__ import annotations`).
+            ta = None
+        _type_adapter_cache[cls] = ta
+        return ta
+
+
 def is_uuid_canonical(val: Any) -> bool:
     """Check if string is valid UUID in canonical format.
 
@@ -146,10 +166,18 @@ def deserialize_object(
                 if key != "__model__"
             }
             try:
-                # Works for BaseModel, pydantic dataclasses, and plain dataclasses alike.
-                # For pydantic dataclasses, __bytes__ tags are already decoded to bytes
-                # by the recursive deserialize_object calls above.
-                model: object = model_class(**deserialized_data)
+                if is_dataclass(model_class) and (adapter := _get_type_adapter(model_class)):
+                    # Dataclasses: use TypeAdapter for proper type coercion
+                    # (datetime from ISO strings, nested unions, etc.).
+                    # Falls back to direct construction when annotations are
+                    # unresolvable (e.g. TYPE_CHECKING-guarded imports).
+                    try:
+                        model: object = adapter.validate_python(deserialized_data)
+                    except PydanticUserError:
+                        model = model_class(**deserialized_data)
+                else:
+                    # BaseModel: coercion handled by Pydantic validators.
+                    model = model_class(**deserialized_data)
             except Exception as e:
                 raise ValueError(
                     f"Error deserializing model {model_class}: {e}\nData: {deserialized_data}"

--- a/src/akgentic/core/utils/serializer.py
+++ b/src/akgentic/core/utils/serializer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import base64
 import uuid
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 from datetime import datetime
 from typing import Any
 
@@ -70,17 +70,11 @@ def serialize(value: Any) -> dict[str, Any] | list[Any] | str | None | ActorAddr
         model_dict: dict[str, Any] = value.model_dump()
         return model_dict
     elif is_dataclass(value) and not isinstance(value, type):
-        if hasattr(value, "__pydantic_serializer__"):
-            # Pydantic dataclass: manually serialize with base64 for bytes fields
-            # to avoid UnicodeDecodeError on non-UTF-8 binary data (PNG, JPEG, etc.)
-            result: dict[str, Any] = {}
-            for f in fields(value):
-                result[f.name] = serialize(getattr(value, f.name))
-            return result
-        # Plain dataclass: keep current __model__ tag approach
-        data = asdict(value)
-        data["__model__"] = serialize_type(value)
-        return serialize(data)
+        result: dict[str, Any] = {}
+        for f in fields(value):
+            result[f.name] = serialize(getattr(value, f.name))
+        result["__model__"] = serialize_type(value)
+        return result
     else:
         return to_jsonable_python(value)  # type: ignore[no-any-return]
 

--- a/tests/core/test_serializer.py
+++ b/tests/core/test_serializer.py
@@ -414,8 +414,8 @@ class TestPydanticDataclassSerialization:
         result = serialize(obj)
 
         assert isinstance(result, dict)
-        # Pydantic dataclass should NOT have __model__ tag (AC-1)
-        assert "__model__" not in result
+        # Dataclass gets a __model__ tag for deserialization
+        assert "__model__" in result
         # Binary data should be a __bytes__ tagged dict with base64 content
         assert "data" in result
         assert isinstance(result["data"], dict)
@@ -532,20 +532,17 @@ class TestPydanticDataclassSerialization:
             payload=FakeBinaryContent(data=binary_data, media_type="image/jpeg"),
         )
 
-        # Serialize — asdict() flattens everything, but bytes get __bytes__ tags
         serialized = serialize(original)
         assert isinstance(serialized, dict)
         assert "__model__" in serialized
 
-        # Deserialize — plain dataclass reconstructed, but nested pydantic dataclass
-        # becomes a dict (pre-existing limitation of asdict flattening).
-        # The key check: binary data survives as bytes, not base64 string.
+        # Nested pydantic dataclass is properly reconstructed (not flattened to dict)
         reconstructed = deserialize_object(serialized)
         assert isinstance(reconstructed, PlainEventWithBinary)
         assert reconstructed.event_name == "image_received"
-        # payload is a dict (asdict flattening), but bytes are decoded
-        assert reconstructed.payload["data"] == binary_data  # type: ignore[index]
-        assert reconstructed.payload["media_type"] == "image/jpeg"  # type: ignore[index]
+        assert isinstance(reconstructed.payload, FakeBinaryContent)
+        assert reconstructed.payload.data == binary_data
+        assert reconstructed.payload.media_type == "image/jpeg"
 
     def test_empty_bytes_round_trip(self) -> None:
         """Empty bytes should round-trip correctly."""


### PR DESCRIPTION
## Summary

- Replace `dataclasses.asdict()` with field-by-field iteration for ALL dataclasses in the serializer — eliminates recursive flattening of nested dataclass types
- Add `TypeAdapter`-based deserialization with caching for proper type coercion (datetime, nested unions) with fallback to direct construction
- Narrow `init_llm_context` signature from `list[Any]` to `list[Message]` for type safety

**Fixes**: nested pydantic-ai types (`ModelRequest`, `ModelResponse`) inside `LlmMessageEvent` were reconstructed as plain dicts instead of their original types after round-trip serialization (known limitation from story 4.4).

Closes #27

| Commit | Scope |
|--------|-------|
| `aff9280` fix: replace asdict with field iteration and TypeAdapter | serializer.py, deserializer.py, test_serializer.py |
| `e1695d1` refactor: narrow init_llm_context signature to list[Message] | agent.py |

🤖 Generated with [Claude Code](https://claude.com/claude-code)