### PR TITLE
feat: persist EventMessage in orchestrator and add get_events() query

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -376,6 +376,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             message: EventMessage containing the event type and payload
             sender: ActorAddress of sending agent
         """
+        self.messages.append(message)
         self._notify_subscribers("on_message", message)
 
     def restore_message(self, message: Message) -> None:
@@ -495,6 +496,31 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             return requests, answers
 
         return self.messages
+
+    def get_events(
+        self,
+        agent_id: str | None = None,
+        event_class: type | None = None,
+    ) -> list[EventMessage]:
+        """Query stored EventMessages with optional filters.
+
+        Args:
+            agent_id: Filter by sender agent_id (optional).
+            event_class: Filter by event payload class via isinstance (optional).
+
+        Returns:
+            List of matching EventMessage instances.
+        """
+        return [
+            msg
+            for msg in self.messages
+            if isinstance(msg, EventMessage)
+            and (
+                agent_id is None
+                or (msg.sender is not None and str(msg.sender.agent_id) == agent_id)
+            )
+            and (event_class is None or isinstance(msg.event, event_class))
+        ]
 
     def get_states(self) -> dict[str, BaseState]:
         """Get all agent states tracked by orchestrator.

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,6 +1,7 @@
 """Tests for Orchestrator agent."""
 
 from collections.abc import Generator
+from dataclasses import dataclass
 from typing import Never
 
 import pykka
@@ -11,6 +12,7 @@ from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.messages.orchestrator import EventMessage
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 
 
@@ -375,5 +377,242 @@ class TestRestoreMessage:
         # We verify indirectly: the orchestrator is alive and functional
         team = orch_proxy.get_team()
         assert team == []
+
+        system.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test event types for event_class filtering
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CostEvent:
+    """Test event type for cost tracking."""
+
+    amount: float
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    """Test event type for usage tracking."""
+
+    tokens: int
+
+
+def _make_event_message(
+    event: object,
+    agent_name: str,
+    agent_role: str,
+    orchestrator_addr: object,
+) -> EventMessage:
+    """Create an EventMessage and initialise its sender field.
+
+    Uses ``restore_message`` on the orchestrator proxy so the message
+    gets a proper sender derived from a real actor address.  To keep
+    tests simple we use a lightweight helper actor for sender addresses.
+    """
+    msg = EventMessage(event=event)
+    return msg
+
+
+class TestEventMessagePersistence:
+    """Tests for EventMessage persistence (AC #1, #2) — Task 3."""
+
+    def test_receive_event_message_appends_to_messages(self) -> None:
+        """receiveMsg_EventMessage appends to self.messages (AC #1)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        msg = EventMessage(event=CostEvent(amount=1.5))
+        msg.init(orch_addr, None)
+
+        proxy.receiveMsg_EventMessage(msg, orch_addr)
+
+        assert msg in proxy.messages
+        system.shutdown()
+
+    def test_event_message_appears_in_get_messages(self) -> None:
+        """EventMessage appears in get_messages() (AC #2)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        msg = EventMessage(event=CostEvent(amount=2.0))
+        msg.init(orch_addr, None)
+        proxy.receiveMsg_EventMessage(msg, orch_addr)
+
+        all_messages = proxy.get_messages()
+        event_messages = [m for m in all_messages if isinstance(m, EventMessage)]
+        assert len(event_messages) == 1
+        assert event_messages[0] is msg
+
+        system.shutdown()
+
+    def test_subscribers_still_notified_after_persistence(self) -> None:
+        """Subscribers receive on_message after EventMessage is persisted (AC #1)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        sub = RecordingSubscriber()
+        proxy.subscribe(sub)
+
+        msg = EventMessage(event=CostEvent(amount=3.0))
+        msg.init(orch_addr, None)
+        proxy.receiveMsg_EventMessage(msg, orch_addr)
+
+        # Subscriber was notified
+        assert len(sub.messages) == 1
+        assert sub.messages[0] is msg
+
+        # AND message was persisted
+        assert msg in proxy.messages
+
+        system.shutdown()
+
+
+class TestGetEvents:
+    """Tests for get_events() query method (AC #3–#7) — Task 4."""
+
+    def test_get_events_no_filter_returns_all(self) -> None:
+        """get_events() with no args returns all EventMessages (AC #3)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        msg1 = EventMessage(event=CostEvent(amount=1.0))
+        msg1.init(orch_addr, None)
+        msg2 = EventMessage(event=UsageEvent(tokens=100))
+        msg2.init(orch_addr, None)
+
+        proxy.receiveMsg_EventMessage(msg1, orch_addr)
+        proxy.receiveMsg_EventMessage(msg2, orch_addr)
+
+        # Also add a non-event message to verify filtering
+        proxy.restore_message(UserMessage(content="not an event"))
+
+        events = proxy.get_events()
+        assert len(events) == 2
+        assert msg1 in events
+        assert msg2 in events
+
+        system.shutdown()
+
+    def test_get_events_agent_id_filter(self) -> None:
+        """get_events(agent_id=...) filters by sender agent_id (AC #4)."""
+        system = ActorSystem()
+
+        # Create two orchestrators to get different addresses for filtering
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        agent_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="worker-a", role="Worker"),
+            restoring=True,
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        msg_orch = EventMessage(event=CostEvent(amount=1.0))
+        msg_orch.init(orch_addr, None)
+
+        msg_agent = EventMessage(event=CostEvent(amount=2.0))
+        msg_agent.init(agent_addr, None)
+
+        proxy.receiveMsg_EventMessage(msg_orch, orch_addr)
+        proxy.receiveMsg_EventMessage(msg_agent, agent_addr)
+
+        # Filter by agent_addr's agent_id
+        filtered = proxy.get_events(agent_id=str(agent_addr.agent_id))
+        assert len(filtered) == 1
+        assert filtered[0] is msg_agent
+
+        system.shutdown()
+
+    def test_get_events_event_class_filter(self) -> None:
+        """get_events(event_class=...) filters by event payload type (AC #5)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        msg_cost = EventMessage(event=CostEvent(amount=1.0))
+        msg_cost.init(orch_addr, None)
+        msg_usage = EventMessage(event=UsageEvent(tokens=100))
+        msg_usage.init(orch_addr, None)
+
+        proxy.receiveMsg_EventMessage(msg_cost, orch_addr)
+        proxy.receiveMsg_EventMessage(msg_usage, orch_addr)
+
+        filtered = proxy.get_events(event_class=CostEvent)
+        assert len(filtered) == 1
+        assert filtered[0] is msg_cost
+
+        system.shutdown()
+
+    def test_get_events_combined_filters(self) -> None:
+        """get_events(agent_id=..., event_class=...) applies both filters (AC #6)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        agent_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="worker-b", role="Worker"),
+            restoring=True,
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        # Four messages: 2 senders x 2 event types
+        msg1 = EventMessage(event=CostEvent(amount=1.0))
+        msg1.init(orch_addr, None)
+        msg2 = EventMessage(event=UsageEvent(tokens=50))
+        msg2.init(orch_addr, None)
+        msg3 = EventMessage(event=CostEvent(amount=2.0))
+        msg3.init(agent_addr, None)
+        msg4 = EventMessage(event=UsageEvent(tokens=99))
+        msg4.init(agent_addr, None)
+
+        for m in (msg1, msg2, msg3, msg4):
+            proxy.receiveMsg_EventMessage(m, orch_addr)
+
+        # Only agent_addr + CostEvent → msg3
+        filtered = proxy.get_events(
+            agent_id=str(agent_addr.agent_id),
+            event_class=CostEvent,
+        )
+        assert len(filtered) == 1
+        assert filtered[0] is msg3
+
+        system.shutdown()
+
+    def test_get_events_empty_result(self) -> None:
+        """get_events() returns empty list when no EventMessages match (AC #7)."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        # Add a non-matching event
+        msg = EventMessage(event=CostEvent(amount=1.0))
+        msg.init(orch_addr, None)
+        proxy.receiveMsg_EventMessage(msg, orch_addr)
+
+        # Filter by a class that doesn't match
+        filtered = proxy.get_events(event_class=UsageEvent)
+        assert filtered == []
+
+        system.shutdown()
+
+    def test_get_events_no_events_at_all(self) -> None:
+        """get_events() returns empty list when no EventMessages exist."""
+        system = ActorSystem()
+        orch_addr = system.createActor(Orchestrator, restoring=True)
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        # Only non-event messages
+        proxy.restore_message(UserMessage(content="not an event"))
+
+        filtered = proxy.get_events()
+        assert filtered == []
 
         system.shutdown()

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -400,21 +400,6 @@ class UsageEvent:
     tokens: int
 
 
-def _make_event_message(
-    event: object,
-    agent_name: str,
-    agent_role: str,
-    orchestrator_addr: object,
-) -> EventMessage:
-    """Create an EventMessage and initialise its sender field.
-
-    Uses ``restore_message`` on the orchestrator proxy so the message
-    gets a proper sender derived from a real actor address.  To keep
-    tests simple we use a lightweight helper actor for sender addresses.
-    """
-    msg = EventMessage(event=event)
-    return msg
-
 
 class TestEventMessagePersistence:
     """Tests for EventMessage persistence (AC #1, #2) — Task 3."""


### PR DESCRIPTION
## Summary
- Fix receiveMsg_EventMessage to append to self.messages before notifying subscribers
- Add get_events(agent_id, event_class) generic query method on Orchestrator
- 9 new tests covering persistence fix and query filtering

Relates to b12consulting/akgentic-core#29