### PR TITLE
docs: update README with EventMessage persistence and get_events() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ class WorkerAgent(Akgent[WorkerConfig, WorkerState]):
 The `Orchestrator` is always the **root actor** of a team. It serves as the
 central coordinator for:
 
-- **Telemetry** — records every lifecycle event and message exchange
+- **Telemetry** — records every lifecycle event and message exchange (including `EventMessage`)
 - **Team roster** — tracks which agents are alive via `StartMessage`/`StopMessage`
 - **State snapshots** — stores the latest `BaseState` for each agent
 - **Pub/sub** — distributes events to `EventSubscriber` implementations
@@ -502,6 +502,7 @@ orch.get_team()                    # Active agent addresses (excludes Orchestrat
 orch.get_team_member("@Writer")    # Find by name
 orch.get_messages()                # Full telemetry log
 orch.get_states()                  # Latest state per agent
+orch.get_events()                  # All EventMessages (optional agent_id/event_class filters)
 ```
 
 ### `team_id` Inheritance


### PR DESCRIPTION
## Summary
- Document `EventMessage` persistence in the Orchestrator telemetry section
- Add `orch.get_events()` to the orchestrator API usage example

Relates to #31

## Related PRs (ADR-06 README updates)
| Package | PR |
|---------|-----|
| **akgentic-core** | This PR (#32) |
| akgentic-llm | b12consulting/akgentic-llm#26 |
| akgentic-agent | b12consulting/akgentic-agent#30 |

**Merge order:** core → llm → agent