### PR TITLE
feat: add set_restoring() to EventSubscriber protocol

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -111,6 +111,18 @@ class EventSubscriber(Protocol):
         - PostgresEventSubscriber: Persists events to PostgreSQL
     """
 
+    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+        """Toggle restore-replay guard.
+
+        Called by ``TeamManager.resume_team()`` before and after replaying
+        persisted events. Each subscriber decides independently whether to
+        skip processing during restore. Default implementation is a no-op.
+
+        Args:
+            restoring: ``True`` when replay starts, ``False`` when it ends.
+        """
+        ...
+
     def on_stop(self) -> None:
         """Called when an orchestrator stops."""
         ...


### PR DESCRIPTION
## Summary
- Add `set_restoring()` method to the `EventSubscriber` protocol in the orchestrator, enabling subscribers to be toggled during event replay/restore operations

## Related PRs (merge in order)
1. **akgentic-core** — b12consulting/akgentic-core#34 ← this PR
2. **akgentic-team** — b12consulting/akgentic-team#74
3. **akgentic-infra** — b12consulting/akgentic-infra#174
4. **akgentic-frontend** — b12consulting/akgentic-frontend#12