### PR TITLE
Remove stop() from ActorAddress ABC and implementations

### DIFF
--- a/src/akgentic/core/actor_address.py
+++ b/src/akgentic/core/actor_address.py
@@ -111,15 +111,6 @@ class ActorAddress(ABC):
         ...
 
     @abstractmethod
-    def stop(self) -> None:
-        """Stop the actor associated with this address.
-
-        Raises:
-            RuntimeError: If this address cannot be stopped (e.g., proxy address).
-        """
-        ...
-
-    @abstractmethod
     def is_alive(self) -> bool:
         """Check if this actor is still running.
 

--- a/src/akgentic/core/actor_address_impl.py
+++ b/src/akgentic/core/actor_address_impl.py
@@ -168,10 +168,6 @@ class ActorAddressImpl(ActorAddress):
             "user_message": self.handle_user_message(),
         }
 
-    def stop(self) -> None:
-        """Stop the underlying actor."""
-        self._actor_ref.stop()
-
     def __repr__(self) -> str:
         """String representation for debugging."""
         return f"<ActorAddress {self.role} {self.name} ({self.agent_id})>"
@@ -277,10 +273,6 @@ class ActorAddressProxy(ActorAddress):
         raise RuntimeError(
             f"Cannot send message from mock actor address {self.name} - actor not alive"
         )
-
-    def stop(self) -> None:
-        """Stop the underlying actor."""
-        raise RuntimeError(f"Cannot stop mock actor address {self.name} - actor not alive")
 
     def is_alive(self) -> bool:
         """Assume the remote/proxied actor is alive.


### PR DESCRIPTION
## Summary

- Remove `stop()` abstract method from `ActorAddress` ABC (8 lines)
- Remove `stop()` from `ActorAddressImpl` (3 lines, called `_actor_ref.stop()`)
- Remove `stop()` from `ActorAddressProxy` (3 lines, raised `RuntimeError`)
- `ActorAddressStopped` inherits removal from parent — no explicit `stop()` existed

**Breaking change**: Downstream packages calling `address.stop()` will need to migrate to proxy-based `actor_system.proxy_ask(address, Akgent).stop()`. Affected packages: `akgentic-tool`, `akgentic-team`. See ADR-006.

## Verification

- 414 tests pass, 89.47% coverage (threshold: 80%)
- mypy strict: clean (17 source files)
- ruff check: clean
- Zero test files required changes — all existing `.stop()` calls are Pykka `ActorRef.stop()` or proxy-based `Akgent.stop()` override

Closes #35