### PR TITLE
fix: shutdown race and receiveMessage logging

### DIFF
--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -12,6 +12,7 @@ import uuid
 from collections import deque
 from collections.abc import Generator
 from contextlib import contextmanager
+from time import sleep
 from typing import Any, TypeVar, cast
 
 import pykka
@@ -253,7 +254,15 @@ class ActorSystem(ExecutionContext):
             except Exception as e:
                 logger.error(f"Error: Failed to stop actor: {e}")
 
-        # Final cleanup: stop any remaining actors
+        # Pykka's proxy().stop() future resolves when the stop() method returns,
+        # NOT when the actor is fully deregistered. Internally, stop() sends 
+        # (fire-and-forget) a _ActorStop() messages to the actor's own mailbox.
+        # The actor thread must still process that message, run on_stop(), and 
+        # deregister from ActorRegistry. Without this pause, get_all() below may see
+        # actors that have accepted the stop request but haven't finished processing it yet.
+        sleep(0.2)
+
+        # Final cleanup: force-stop any actors still in the registry
         remaining_actors = pykka.ActorRegistry.get_all()
         remaining_actors_classes = [actor.actor_class.__name__ for actor in remaining_actors]
         if remaining_actors:

--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -434,7 +434,7 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
             Result from message handler.
         """
         logger.info(
-            f"[{self.config.name}-{self.myAddress}] receiveMessage: {message.__class__.__name__}"
+            f"[{self.config.name}-{self.team_id}] receiveMessage: {message.__class__.__name__}"
         )
         if isinstance(message, Message):
             self._current_message = message


### PR DESCRIPTION
## Summary

- Add 0.2s pause in `ActorSystem.shutdown()` after stop futures resolve, before checking `ActorRegistry.get_all()`. Pykka's `proxy().stop()` future resolves when `stop()` returns, not when the actor deregisters — the poison pill is still in the mailbox.
- Change `receiveMessage` log from `[name-myAddress]` to `[name-team_id]` for better debugging context.

Closes #39