### PR TITLE
Extract snapshot_addresses utility and add container support

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -14,7 +14,6 @@ from typing import Protocol, overload, override
 from pydantic import Field
 
 from akgentic.core.actor_address import ActorAddress
-from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
@@ -269,25 +268,17 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         except ValueError:
             pass
 
-    def _snapshot_for_subscribers(self, message: Message) -> Message:
+    @staticmethod
+    def snapshot_for_subscribers(message: Message) -> Message:
         """Create a subscriber-safe copy with serialized actor addresses.
 
-        Introspects all Pydantic fields on the concrete message subclass and
-        replaces every live ``ActorAddressImpl`` value with an
-        ``ActorAddressProxy`` snapshot (plain data).  This covers the base
-        ``sender``/``recipient`` fields **and** subclass-specific address
-        fields such as ``StartMessage.parent`` or ``SentMessage.recipient``.
+        Delegates to :func:`akgentic.core.utils.snapshot_addresses` which
+        recursively walks Pydantic model fields and replaces every live
+        ``ActorAddressImpl`` with an ``ActorAddressProxy`` snapshot.
         """
-        updates: dict[str, ActorAddressProxy | Message] = {}
-        for name in type(message).model_fields:
-            value = getattr(message, name)
-            if isinstance(value, ActorAddressImpl):
-                updates[name] = ActorAddressProxy(value.serialize())
-            elif isinstance(value, Message):
-                updates[name] = self._snapshot_for_subscribers(value)
-        if updates:
-            return message.model_copy(update=updates)
-        return message
+        from akgentic.core.utils import snapshot_addresses
+
+        return snapshot_addresses(message)  # type: ignore[return-value]
 
     def _notify_subscribers(self, event_method: str, message: Message | None = None) -> None:
         """Unified subscriber notification with fault tolerance.
@@ -297,7 +288,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             message: Message to pass to subscriber
         """
         if message is not None:
-            message = self._snapshot_for_subscribers(message)
+            message = self.snapshot_for_subscribers(message)
         for subscriber in self.subscribers:
             try:
                 method = getattr(subscriber, event_method)

--- a/src/akgentic/core/utils/__init__.py
+++ b/src/akgentic/core/utils/__init__.py
@@ -17,6 +17,7 @@ from akgentic.core.utils.serializer import (
     serialize,
     serialize_base_model,
     serialize_type,
+    snapshot_addresses,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "serialize",
     "serialize_base_model",
     "serialize_type",
+    "snapshot_addresses",
 ]

--- a/src/akgentic/core/utils/serializer.py
+++ b/src/akgentic/core/utils/serializer.py
@@ -124,6 +124,58 @@ def serialize_base_model(cls: BaseModel) -> dict[str, Any]:
     return data
 
 
+def _snapshot_value(value: Any) -> Any:  # noqa: ANN401
+    """Recursively snapshot a single value, replacing live actor addresses.
+
+    Handles ``ActorAddressImpl``, ``BaseModel``, ``list``, ``tuple``,
+    ``set``, and ``dict`` values.  Returns the original object unchanged
+    when no replacements are needed.
+    """
+    from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+    if isinstance(value, ActorAddressImpl):
+        return ActorAddressProxy(value.serialize())
+    if isinstance(value, BaseModel):
+        return snapshot_addresses(value)
+    if isinstance(value, (list, tuple, set)):
+        items = [_snapshot_value(item) for item in value]
+        if all(new is orig for new, orig in zip(items, value)):
+            return value
+        return type(value)(items)
+    if isinstance(value, dict):
+        new_dict = {k: _snapshot_value(v) for k, v in value.items()}
+        if all(new_dict[k] is v for k, v in value.items()):
+            return value
+        return new_dict
+    return value
+
+
+def snapshot_addresses(model: BaseModel) -> BaseModel:
+    """Replace live ``ActorAddressImpl`` references with ``ActorAddressProxy`` snapshots.
+
+    Walks every Pydantic field on the concrete model class and recursively
+    processes values — including nested ``BaseModel`` instances, ``list``,
+    ``dict``, ``tuple``, and ``set`` containers.  Returns the original
+    instance unchanged when no replacements are needed.
+
+    Args:
+        model: A Pydantic ``BaseModel`` instance (typically a ``Message``).
+
+    Returns:
+        The original model if no live addresses were found, or a shallow
+        ``model_copy`` with all ``ActorAddressImpl`` values replaced.
+    """
+    updates: dict[str, Any] = {}
+    for name in type(model).model_fields:
+        value = getattr(model, name)
+        snapshotted = _snapshot_value(value)
+        if snapshotted is not value:
+            updates[name] = snapshotted
+    if updates:
+        return model.model_copy(update=updates)
+    return model
+
+
 class SerializableBaseModel(BaseModel):
     """Base class for models that need proper serialization of UUID, ActorAddress, etc.
 

--- a/tests/core/test_serializer.py
+++ b/tests/core/test_serializer.py
@@ -8,10 +8,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import pydantic
 import pydantic.dataclasses
 import pytest
 from pydantic import BaseModel
 
+from akgentic.core.actor_address import ActorAddress
 from akgentic.core.messages.message import Message, UserMessage
 from akgentic.core.utils.deserializer import (
     ActorAddressDict,
@@ -26,6 +28,7 @@ from akgentic.core.utils.serializer import (
     serialize,
     serialize_base_model,
     serialize_type,
+    snapshot_addresses,
 )
 
 
@@ -549,3 +552,135 @@ class TestPydanticDataclassSerialization:
         result = serialize(b"")
         assert result == {"__bytes__": ""}
         assert deserialize_object(result) == b""
+
+
+# ---------------------------------------------------------------------------
+# snapshot_addresses tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_impl(
+    name: str = "agent", role: str = "Agent",
+) -> ActorAddress:
+    """Create a mock ActorAddressImpl without a real actor system."""
+    from unittest.mock import MagicMock
+
+    from akgentic.core.actor_address_impl import ActorAddressImpl
+
+    config = MagicMock()
+    config.name = name
+    config.role = role
+    config.squad_id = None
+
+    actor = MagicMock()
+    actor.agent_id = uuid.uuid4()
+    actor.config = config
+    actor.team_id = uuid.uuid4()
+    actor.receiveMsg_UserMessage = MagicMock()
+    actor.__class__ = type(
+        "MockAgent", (), {"__module__": "test.agents", "__name__": "MockAgent"},
+    )
+
+    actor_ref = MagicMock()
+    actor_ref._actor_weakref = lambda: actor
+    actor_ref.is_alive.return_value = True
+    actor_ref.actor_urn = f"urn:mock:{name}"
+
+    return ActorAddressImpl(actor_ref)
+
+
+class _ListModel(BaseModel):
+    """Test model with a list of ActorAddress."""
+
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+    addresses: list[ActorAddress]
+
+
+class _DictModel(BaseModel):
+    """Test model with a dict containing ActorAddress values."""
+
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+    mapping: dict[str, ActorAddress]
+
+
+class _NestedListModel(BaseModel):
+    """Test model with a list of Messages."""
+
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+    messages: list[Message]
+
+
+class TestSnapshotAddresses:
+    """Tests for snapshot_addresses utility."""
+
+    def test_list_of_addresses(self) -> None:
+        """ActorAddressImpl inside a list field are replaced."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+        addr1 = _make_mock_impl("a1", "Role1")
+        addr2 = _make_mock_impl("a2", "Role2")
+        model = _ListModel(addresses=[addr1, addr2])
+
+        result = snapshot_addresses(model)
+
+        assert result is not model
+        assert len(result.addresses) == 2
+        for addr in result.addresses:
+            assert isinstance(addr, ActorAddressProxy)
+            assert not isinstance(addr, ActorAddressImpl)
+        assert result.addresses[0].name == "a1"
+        assert result.addresses[1].name == "a2"
+
+    def test_dict_of_addresses(self) -> None:
+        """ActorAddressImpl inside a dict field are replaced."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+        addr = _make_mock_impl("mapped", "Mapper")
+        model = _DictModel(mapping={"key": addr})
+
+        result = snapshot_addresses(model)
+
+        assert result is not model
+        assert isinstance(result.mapping["key"], ActorAddressProxy)
+        assert not isinstance(result.mapping["key"], ActorAddressImpl)
+        assert result.mapping["key"].name == "mapped"
+
+    def test_list_of_messages(self) -> None:
+        """Messages nested inside a list have their addresses replaced."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+        addr = _make_mock_impl("inner", "Inner")
+        inner_msg = UserMessage(content="hello")
+        inner_msg.sender = addr
+
+        model = _NestedListModel(messages=[inner_msg])
+
+        result = snapshot_addresses(model)
+
+        assert result is not model
+        assert isinstance(result.messages[0].sender, ActorAddressProxy)
+        assert not isinstance(result.messages[0].sender, ActorAddressImpl)
+        assert result.messages[0].sender.name == "inner"
+
+    def test_no_copy_when_no_impl(self) -> None:
+        """Original model returned unchanged when no ActorAddressImpl present."""
+        model = _ListModel(addresses=[])
+        result = snapshot_addresses(model)
+        assert result is model
+
+    def test_mixed_list_only_impl_replaced(self) -> None:
+        """In a mixed list, only ActorAddressImpl are replaced; Proxy kept as-is."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+        impl = _make_mock_impl("live", "Live")
+        proxy = ActorAddressProxy(impl.serialize())
+
+        model = _ListModel(addresses=[impl, proxy])
+
+        result = snapshot_addresses(model)
+
+        assert result is not model
+        assert isinstance(result.addresses[0], ActorAddressProxy)
+        assert not isinstance(result.addresses[0], ActorAddressImpl)
+        # The pre-existing proxy should be kept unchanged
+        assert result.addresses[1] is proxy


### PR DESCRIPTION
## Summary

- Extract `snapshot_addresses()` utility from `Orchestrator._snapshot_for_subscribers()` into `utils/serializer.py`, following the existing `serialize()` recursive pattern
- Add recursive handling for nested `BaseModel`, `list`, `dict`, `tuple`, `set` containers
- Orchestrator `snapshot_for_subscribers()` becomes a thin `@staticmethod` delegating to the utility
- 5 new unit tests in `test_serializer.py` covering list/dict/nested-message/mixed-container scenarios

Relates to #41

## Test plan

- [x] `pytest packages/akgentic-core/tests/` — all 424 tests pass
- [x] `mypy packages/akgentic-core/src/` — strict, zero errors  
- [x] `ruff check packages/akgentic-core/src/` — zero errors