### PR TITLE
Fix getChildrenOrCreate to use synchronous children lookup

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -9,7 +9,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable
-from typing import Protocol, overload, override
+from typing import Any, Protocol, overload, override
 
 from pydantic import Field
 
@@ -429,7 +429,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         logger.info("Orchestrator restoration complete, resuming normal operation")
 
     def getChildrenOrCreate(  # noqa: N802
-        self, actor_class: type[Akgent], config: BaseConfig
+        self, actor_class: type[Akgent[Any, Any]], config: BaseConfig
     ) -> ActorAddress:
         """Return an existing live child by name, or create a new one.
 

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -428,6 +428,27 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._restoring = False
         logger.info("Orchestrator restoration complete, resuming normal operation")
 
+    def getChildrenOrCreate(  # noqa: N802
+        self, actor_class: type[Akgent], config: BaseConfig
+    ) -> ActorAddress:
+        """Return an existing live child by name, or create a new one.
+
+        Uses the synchronous ``_children`` list rather than
+        ``get_team_member()`` (which depends on the asynchronous
+        ``StartMessage`` arrival) to avoid race conditions when
+        multiple callers request the same singleton concurrently.
+
+        Args:
+            actor_class: Class of the agent to instantiate.
+            config: Configuration for the new agent.
+        Returns:
+            ActorAddress of the existing child or newly created agent.
+        """
+        for child in self._children:
+            if child.is_alive() and child.name == config.name:
+                return child
+        return self.createActor(actor_class, config=config)
+
     def get_team(self) -> list[ActorAddress]:
         """Get list of active agents (excludes Orchestrator role).
 

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -615,6 +615,125 @@ class TestGetEvents:
         system.shutdown()
 
 
+class TestGetChildrenOrCreate:
+    """Tests for Orchestrator.getChildrenOrCreate singleton lookup."""
+
+    def test_creates_child_when_absent(self) -> None:
+        """getChildrenOrCreate creates a new child when none exists with the name."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        child_addr = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+
+        assert child_addr.is_alive()
+        assert child_addr.name == "#Foo"
+
+        system.shutdown()
+
+    def test_returns_existing_live_child(self) -> None:
+        """getChildrenOrCreate returns existing live child instead of creating a duplicate."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        first = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+        second = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+
+        assert first.agent_id == second.agent_id
+        assert first.name == second.name
+
+        system.shutdown()
+
+    def test_dead_child_is_not_returned(self) -> None:
+        """getChildrenOrCreate creates a new actor when the existing child is dead."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        first = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+        first_id = first.agent_id
+
+        # Stop the child
+        system.proxy_ask(first, Akgent).stop()
+
+        # Now request the same name again
+        second = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+
+        assert second.is_alive()
+        assert second.agent_id != first_id
+
+        system.shutdown()
+
+    def test_back_to_back_idempotency(self) -> None:
+        """Two sequential calls with same name return same ActorAddress and only one actor."""
+        config = BaseConfig(name="orchestrator", role="Orchestrator")
+        orch_ref = Orchestrator.start(config=config)
+        orch = orch_ref.proxy()
+
+        addr1 = orch.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
+        ).get()
+        addr2 = orch.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
+        ).get()
+
+        # Same actor returned
+        assert addr1.agent_id == addr2.agent_id
+
+        # Verify only one child with that name by checking team via messages
+        # (both calls should have resulted in only one StartMessage for #Bar)
+        messages = orch.get_messages().get()
+        bar_starts = [
+            m for m in messages
+            if isinstance(m, StartMessage) and m.config.name == "#Bar"
+        ]
+        assert len(bar_starts) == 1
+
+        orch_ref.stop()
+
+    def test_different_names_create_different_children(self) -> None:
+        """getChildrenOrCreate creates separate children for different names."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        foo = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
+        )
+        bar = proxy.getChildrenOrCreate(
+            SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
+        )
+
+        assert foo.agent_id != bar.agent_id
+        assert foo.name == "#Foo"
+        assert bar.name == "#Bar"
+
+        system.shutdown()
+
+
 class TestSnapshotForSubscribers:
     """Tests for _snapshot_for_subscribers address serialization (AC: 1-4)."""
 

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -686,30 +686,33 @@ class TestGetChildrenOrCreate:
 
     def test_back_to_back_idempotency(self) -> None:
         """Two sequential calls with same name return same ActorAddress and only one actor."""
-        config = BaseConfig(name="orchestrator", role="Orchestrator")
-        orch_ref = Orchestrator.start(config=config)
-        orch = orch_ref.proxy()
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        proxy = system.proxy_ask(orch_addr, Orchestrator)
 
-        addr1 = orch.getChildrenOrCreate(
+        addr1 = proxy.getChildrenOrCreate(
             SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
-        ).get()
-        addr2 = orch.getChildrenOrCreate(
+        )
+        addr2 = proxy.getChildrenOrCreate(
             SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
-        ).get()
+        )
 
         # Same actor returned
         assert addr1.agent_id == addr2.agent_id
 
         # Verify only one child with that name by checking team via messages
         # (both calls should have resulted in only one StartMessage for #Bar)
-        messages = orch.get_messages().get()
+        messages = proxy.get_messages()
         bar_starts = [
             m for m in messages
             if isinstance(m, StartMessage) and m.config.name == "#Bar"
         ]
         assert len(bar_starts) == 1
 
-        orch_ref.stop()
+        system.shutdown()
 
     def test_different_names_create_different_children(self) -> None:
         """getChildrenOrCreate creates separate children for different names."""


### PR DESCRIPTION
## Summary

- Add `getChildrenOrCreate` method to `Orchestrator` that uses synchronous `_children` list lookup instead of async `get_team_member()` to avoid race conditions when multiple callers request the same singleton actor concurrently
- 5 unit tests covering: creation when absent, returning existing live child, dead child filtering, back-to-back idempotency, and different names creating different children
- Code review fix: standardized `test_back_to_back_idempotency` to use `ActorSystem` pattern consistent with other tests

Closes #48
