### PR TITLE
fix: close event loop in Akgent.on_stop()

### DIFF
--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -540,6 +540,7 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
         """
         if self._event_loop.is_running():
             self._event_loop.stop()
+        self._event_loop.close()
 
         self._notify_orchestrator(StopMessage())
         logger.info(f"[{self.config.name}] Stopped.")


### PR DESCRIPTION
## Summary

- Add `self._event_loop.close()` in `Akgent.on_stop()` after `loop.stop()` to release OS resources (selectors, file descriptors) immediately on actor teardown
- Fixes `ResourceWarning: unclosed event loop` emitted during server shutdown when teams are running

Closes #50