### PR TITLE
refactor(akgentic-core): 3-6 delegate inactivity timer stop to EventSubscriber

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -124,7 +124,13 @@ class EventSubscriber(Protocol):
         ...
 
     def on_stop_request(self) -> None:
-        """Called when an orchestrator make a stop request (e.g. inactivity timer fires)."""
+        """Called when an orchestrator makes a stop request (e.g. inactivity timer fires).
+
+        Default implementation is a no-op — subscribers (e.g. ``TimerStopSubscriber``
+        in ``akgentic-team``) override this to decide how to actually stop the
+        team. The orchestrator itself does NOT stop on this signal; shutdown is
+        the subscriber's responsibility.
+        """
         ...
 
     def on_stop(self) -> None:

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -18,7 +18,7 @@ from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
-from akgentic.core.messages.message import Message, StopRecursively
+from akgentic.core.messages.message import Message
 from akgentic.core.messages.orchestrator import (
     ErrorMessage,
     EventMessage,
@@ -121,6 +121,10 @@ class EventSubscriber(Protocol):
         Args:
             restoring: ``True`` when replay starts, ``False`` when it ends.
         """
+        ...
+
+    def on_stop_request(self) -> None:
+        """Called when an orchestrator make a stop request (e.g. inactivity timer fires)."""
         ...
 
     def on_stop(self) -> None:
@@ -237,9 +241,9 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         Any exception during the stop is caught and logged to prevent the
         timer thread from crashing silently.
         """
-        team_id = getattr(self.config, "team_id", "unknown")
+        team_id = self.team_id
         logger.info(f"Orchestrator timeout after {self._timer.delay}s inactivity (team={team_id})")
-        self.send(self.myAddress, StopRecursively())
+        self._notify_subscribers("on_stop_request")
 
     def get_timer(self) -> Timer:
         """Return the inactivity Timer instance (for testing and introspection).

--- a/tests/core/test_orchestrator_timer.py
+++ b/tests/core/test_orchestrator_timer.py
@@ -1,5 +1,6 @@
 """Unit tests for the Timer helper class and Orchestrator timer integration."""
 
+import logging
 import os
 import threading
 import time
@@ -12,7 +13,7 @@ import pytest
 
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.orchestrator import ErrorMessage, ProcessedMessage, ReceivedMessage
-from akgentic.core.orchestrator import TIMER_DELAY, Orchestrator, Timer
+from akgentic.core.orchestrator import TIMER_DELAY, EventSubscriber, Orchestrator, Timer
 
 
 @pytest.fixture(autouse=True)
@@ -461,18 +462,125 @@ class TestOrchestratorStop:
         assert timer._timer is None
 
 
-class TestOrchestratorTimeoutHandler:
-    """Tests for the _timeout_handler method."""
+class _RecordingStopSubscriber:
+    """Subscriber that records on_stop_request / on_stop / on_message invocations."""
 
-    def test_timeout_causes_orchestrator_to_stop(self) -> None:
-        """After timer fires, orchestrator sends StopRecursively to itself and stops."""
+    def __init__(self) -> None:
+        self.stop_request_count: int = 0
+        self.stop_count: int = 0
+        self.messages: list[object] = []
+
+    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+        """Protocol compliance — no-op for these tests."""
+        pass
+
+    def on_stop_request(self) -> None:
+        self.stop_request_count += 1
+
+    def on_stop(self) -> None:
+        self.stop_count += 1
+
+    def on_message(self, msg: object) -> None:
+        self.messages.append(msg)
+
+
+class TestEventSubscriberProtocol:
+    """AC1: ``on_stop_request`` is part of the ``EventSubscriber`` protocol."""
+
+    def test_on_stop_request_exists_on_protocol(self) -> None:
+        """The ``EventSubscriber`` protocol exposes ``on_stop_request``."""
+        assert hasattr(EventSubscriber, "on_stop_request")
+        assert callable(EventSubscriber.on_stop_request)
+
+    def test_on_stop_request_default_implementation_is_noop(self) -> None:
+        """A subclass that inherits the default definition returns ``None``.
+
+        The protocol body is ``...`` which is compiled to a ``None`` return.
+        Subscribers that do not implement ``on_stop_request`` should therefore
+        silently do nothing.
+        """
+
+        class _MinimalSubscriber(EventSubscriber):
+            pass
+
+        sub = _MinimalSubscriber()
+        # Calling the default method must not raise and must return None
+        assert sub.on_stop_request() is None  # type: ignore[func-returns-value]
+
+
+class TestOrchestratorTimeoutHandler:
+    """AC2/AC3/AC4: ``_timeout_handler`` delegates shutdown via subscribers."""
+
+    def test_timeout_notifies_subscribers_on_stop_request(self) -> None:
+        """AC2: firing the timer calls ``on_stop_request`` on every subscriber."""
+        config = BaseConfig(name="test-orchestrator", role="Orchestrator")
+        orch_ref = Orchestrator.start(config=config)
+        orch = orch_ref.proxy()
+
+        sub = _RecordingStopSubscriber()
+        orch.subscribe(sub).get()
+
+        # Invoke the handler the same way ``threading.Timer`` would —
+        # directly via the callback stored on the Timer. This isolates the
+        # behavioural contract of ``_timeout_handler`` from scheduling noise.
+        timer = orch.get_timer().get()
+        timer.timeout_callback()
+
+        # Give the actor thread a moment to process any internal messages
+        # (snapshot_for_subscribers runs on the caller; subscriber calls are
+        # synchronous within _notify_subscribers, so assertions are immediate).
+        assert sub.stop_request_count == 1
+        # on_stop is a separate lifecycle hook; the timeout must not trigger it
+        assert sub.stop_count == 0
+
+        orch_ref.stop()
+
+    def test_timeout_does_not_stop_orchestrator(self) -> None:
+        """AC2/AC3: the orchestrator stays alive after timer fires.
+
+        The refactor delegates shutdown to the subscriber — the orchestrator
+        no longer sends ``StopRecursively`` to itself on inactivity. This
+        test verifies the actor remains alive after a real timeout fires
+        without any subscriber taking action.
+        """
         with patch.dict(os.environ, {"ORCHESTRATOR_TIMEOUT_DELAY": "1"}):
             config = BaseConfig(name="test-orchestrator", role="Orchestrator")
             orch_ref = Orchestrator.start(config=config)
+            orch = orch_ref.proxy()
 
-            # Poll until the actor dies (fires at ~1s) with a 3s hard ceiling
+            sub = _RecordingStopSubscriber()
+            orch.subscribe(sub).get()
+
+            # Wait past the configured 1s inactivity delay so the timer fires.
+            # Poll up to 3s to confirm the subscriber was notified.
             deadline = time.monotonic() + 3.0
-            while orch_ref.is_alive() and time.monotonic() < deadline:
+            while sub.stop_request_count == 0 and time.monotonic() < deadline:
                 time.sleep(0.1)
 
-            assert not orch_ref.is_alive()
+            # Subscriber was notified at least once
+            assert sub.stop_request_count >= 1
+            # Orchestrator remained alive — shutdown is the subscriber's job now
+            assert orch_ref.is_alive()
+
+            orch_ref.stop()
+
+    def test_timeout_log_uses_actor_team_id(self, caplog: pytest.LogCaptureFixture) -> None:
+        """AC4: the inactivity log line uses the actor's ``team_id`` attribute."""
+        team_id = uuid.uuid4()
+        config = BaseConfig(name="test-orchestrator", role="Orchestrator")
+        orch_ref = Orchestrator.start(config=config, team_id=team_id)
+        orch = orch_ref.proxy()
+
+        try:
+            timer = orch.get_timer().get()
+            with caplog.at_level(logging.INFO, logger="akgentic.core.orchestrator"):
+                # Fire the handler directly (same callback threading.Timer uses)
+                timer.timeout_callback()
+
+            timeout_records = [
+                r for r in caplog.records if "Orchestrator timeout after" in r.getMessage()
+            ]
+            assert len(timeout_records) == 1
+            assert f"team={team_id}" in timeout_records[0].getMessage()
+        finally:
+            orch_ref.stop()

--- a/tests/test_epic3_integration.py
+++ b/tests/test_epic3_integration.py
@@ -4,7 +4,8 @@ Tests the full end-to-end behaviour of the Orchestrator's inactivity timer,
 verifying that:
   - ReceivedMessage pauses the timer (task_started)
   - ProcessedMessage restarts the timer (task_completed)
-  - Orchestrator stops after timeout when no new messages arrive
+  - Subscribers receive ``on_stop_request`` when the timer fires and the
+    orchestrator itself stays alive (shutdown is delegated to the subscriber)
   - Manual stop cancels the timer cleanly
   - WarningError in handler: timer resets properly, no ErrorMessage sent
   - Other exception in handler: timer resets properly, ErrorMessage sent
@@ -96,23 +97,51 @@ class TestOrchestratorTimerIntegration:
         sender_ref.stop()
         orch_ref.stop()
 
-    def test_orchestrator_stops_after_timeout_with_no_new_messages(self) -> None:
-        """Orchestrator stops itself after inactivity timeout if no new messages arrive.
+    def test_timeout_notifies_subscribers_and_orchestrator_stays_alive(self) -> None:
+        """After the inactivity timeout fires, subscribers are notified via
+        ``on_stop_request`` and the orchestrator itself stays alive.
 
-        Uses a 1-second timeout for test speed.
+        The refactor (Story 3.6) delegates shutdown to subscribers — the
+        orchestrator no longer sends ``StopRecursively`` to itself. Uses a
+        1-second timeout for test speed.
         """
+
+        class _StopSub:
+            def __init__(self) -> None:
+                self.stop_request_count = 0
+
+            def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+                pass
+
+            def on_stop_request(self) -> None:
+                self.stop_request_count += 1
+
+            def on_stop(self) -> None:
+                pass
+
+            def on_message(self, msg: Message) -> None:
+                pass
+
         with patch.dict(os.environ, {"ORCHESTRATOR_TIMEOUT_DELAY": "1"}):
             config = BaseConfig(name="orch-timeout-test", role="Orchestrator")
             orch_ref = Orchestrator.start(config=config)
+            orch = orch_ref.proxy()
+
+            sub = _StopSub()
+            orch.subscribe(sub).get()
 
             assert orch_ref.is_alive()
 
-            # Poll until the actor dies (fires at ~1s) with a 3s hard ceiling
+            # Wait for the timer (1s) to fire; poll the subscriber up to 3s.
             deadline = time.monotonic() + 3.0
-            while orch_ref.is_alive() and time.monotonic() < deadline:
+            while sub.stop_request_count == 0 and time.monotonic() < deadline:
                 time.sleep(0.1)
 
-            assert not orch_ref.is_alive()
+            assert sub.stop_request_count >= 1
+            # Orchestrator did NOT self-stop — the subscriber owns shutdown now
+            assert orch_ref.is_alive()
+
+            orch_ref.stop()
 
     def test_timer_resets_on_new_message_after_previous_task_completes(self) -> None:
         """Timer resets correctly through multiple receive/process cycles."""

--- a/tests/test_timer_integration.py
+++ b/tests/test_timer_integration.py
@@ -4,7 +4,8 @@ Tests the full end-to-end behaviour of the Orchestrator's inactivity timer,
 verifying that:
   - ReceivedMessage pauses the timer (task_started)
   - ProcessedMessage restarts the timer (task_completed)
-  - Orchestrator stops after timeout when no new messages arrive
+  - Subscribers receive ``on_stop_request`` when the timer fires and the
+    orchestrator itself stays alive (shutdown is delegated to the subscriber)
   - Manual stop cancels the timer cleanly
   - WarningError in handler: timer resets properly, no ErrorMessage sent
   - Other exception in handler: timer resets properly, ErrorMessage sent
@@ -96,23 +97,51 @@ class TestOrchestratorTimerIntegration:
         sender_ref.stop()
         orch_ref.stop()
 
-    def test_orchestrator_stops_after_timeout_with_no_new_messages(self) -> None:
-        """Orchestrator stops itself after inactivity timeout if no new messages arrive.
+    def test_timeout_notifies_subscribers_and_orchestrator_stays_alive(self) -> None:
+        """After the inactivity timeout fires, subscribers are notified via
+        ``on_stop_request`` and the orchestrator itself stays alive.
 
-        Uses a 1-second timeout for test speed.
+        The refactor (Story 3.6) delegates shutdown to subscribers — the
+        orchestrator no longer sends ``StopRecursively`` to itself. Uses a
+        1-second timeout for test speed.
         """
+
+        class _StopSub:
+            def __init__(self) -> None:
+                self.stop_request_count = 0
+
+            def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+                pass
+
+            def on_stop_request(self) -> None:
+                self.stop_request_count += 1
+
+            def on_stop(self) -> None:
+                pass
+
+            def on_message(self, msg: Message) -> None:
+                pass
+
         with patch.dict(os.environ, {"ORCHESTRATOR_TIMEOUT_DELAY": "1"}):
             config = BaseConfig(name="orch-timeout-test", role="Orchestrator")
             orch_ref = Orchestrator.start(config=config)
+            orch = orch_ref.proxy()
+
+            sub = _StopSub()
+            orch.subscribe(sub).get()
 
             assert orch_ref.is_alive()
 
-            # Poll until the actor dies (fires at ~1s) with a 3s hard ceiling
+            # Wait for the timer (1s) to fire; poll the subscriber up to 3s.
             deadline = time.monotonic() + 3.0
-            while orch_ref.is_alive() and time.monotonic() < deadline:
+            while sub.stop_request_count == 0 and time.monotonic() < deadline:
                 time.sleep(0.1)
 
-            assert not orch_ref.is_alive()
+            assert sub.stop_request_count >= 1
+            # Orchestrator did NOT self-stop — the subscriber owns shutdown now
+            assert orch_ref.is_alive()
+
+            orch_ref.stop()
 
     def test_timer_resets_on_new_message_after_previous_task_completes(self) -> None:
         """Timer resets correctly through multiple receive/process cycles."""


### PR DESCRIPTION
## Summary

Story 3.6 — **Delegate inactivity timer stop to `EventSubscriber`**.

Previously, `Orchestrator._timeout_handler` sent `StopRecursively` to itself
when the inactivity timer fired, coupling `akgentic-core` to a specific
shutdown strategy. This change inverts control: the orchestrator now signals
intent via `self._notify_subscribers("on_stop_request")`, and each subscriber
(e.g. `TimerStopSubscriber` in `akgentic-team`) decides how to actually stop
the team.

The orchestrator no longer self-terminates on inactivity.

See issue #54 for design discussion.

## Changes

- **`EventSubscriber` protocol**: new `on_stop_request()` method with a no-op
  default. Documented as "called when the orchestrator makes a stop request
  (e.g. inactivity timer fires)".
- **`Orchestrator._timeout_handler`**: replaces `self.send(self.myAddress, StopRecursively())`
  with `self._notify_subscribers("on_stop_request")`. Removes the now-unused
  `StopRecursively` import and cleans up the log line to use `self.team_id`
  (the actor property) instead of `getattr(self.config, "team_id", "unknown")`.
- **Tests** (`tests/core/test_orchestrator_timer.py`, `tests/test_epic3_integration.py`,
  `tests/test_timer_integration.py`): cover the protocol addition, the
  delegation behavior, the "orchestrator stays alive" invariant, and the
  team-id log line.
- **Rex fix-up**: expanded the `on_stop_request` docstring (grammar fix
  `make` -> `makes`, plus a sentence clarifying the default is a no-op and
  shutdown is the subscriber's responsibility).

## Acceptance criteria

- [x] **AC1** — `EventSubscriber.on_stop_request(self) -> None` exists on the
  protocol with a no-op default and a clear docstring.
- [x] **AC2** — `_timeout_handler` calls `self._notify_subscribers("on_stop_request")`
  instead of sending `StopRecursively` to itself.
- [x] **AC3** — `from akgentic.core.messages.message import StopRecursively`
  is removed from `orchestrator.py`.
- [x] **AC4** — `_timeout_handler` logs using `self.team_id` (actor property),
  not `getattr(self.config, "team_id", "unknown")`.

## Review status

**PASS** — single low-severity finding (docstring grammar + expansion on
`on_stop_request`) was fixed in the Rex fix-up commit. All ACs are implemented
with test coverage. Full `packages/akgentic-core/` test suite green
(448/448). `mypy --strict` clean on `src/`. `ruff check src/` clean.

Scope confirmed: every edit stayed inside `packages/akgentic-core/`.

Relates to #54
