### PR TITLE
feat(agent_card): coerce config to agent_class-declared ConfigType (#56)

### DIFF
--- a/src/akgentic/core/agent_card.py
+++ b/src/akgentic/core/agent_card.py
@@ -8,11 +8,12 @@ This ensures each agent gets an independent copy, preventing shared mutable stat
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar, cast, get_args, get_origin
+from typing import TYPE_CHECKING, Any, TypeVar, get_args, get_origin
 
 from pydantic import Field, model_validator
 
 from akgentic.core.agent_config import BaseConfig
+from akgentic.core.utils import import_class
 from akgentic.core.utils.serializer import SerializableBaseModel
 
 if TYPE_CHECKING:
@@ -27,6 +28,8 @@ _CONFIG_TYPE_CACHE: dict[type, type[BaseConfig] | None] = {}
 def _resolve_agent_class(value: str | type) -> type:
     """Resolve ``agent_class`` (str FQCN or type) to the actual class.
 
+    Thin wrapper around :func:`akgentic.core.utils.import_class` that adds the
+    type short-circuit and a clearer error for empty / unqualified inputs.
     Shared by ``AgentCard.get_agent_class()`` and the ``config`` coercion
     model-validator.
 
@@ -50,12 +53,7 @@ def _resolve_agent_class(value: str | type) -> type:
             f"(e.g. 'mypackage.agents.MyAgent'), got: {value!r}"
         )
 
-    components = value.split(".")
-    module_path = ".".join(components[:-1])
-    class_name = components[-1]
-
-    module = __import__(module_path, fromlist=[class_name])
-    return cast(type, getattr(module, class_name))
+    return import_class(value)
 
 
 def _extract_config_type(agent_cls: type) -> type[BaseConfig] | None:
@@ -221,9 +219,7 @@ class AgentCard(SerializableBaseModel):
             agent_cls = _resolve_agent_class(agent_class_raw)
         except (ValueError, ImportError, AttributeError) as exc:
             # AC #8: surface import errors as ValidationError via ValueError.
-            raise ValueError(
-                f"Could not resolve agent_class={agent_class_raw!r}: {exc}"
-            ) from exc
+            raise ValueError(f"Could not resolve agent_class={agent_class_raw!r}: {exc}") from exc
 
         config_type = _extract_config_type(agent_cls)
         if config_type is None or config_type is BaseConfig:

--- a/src/akgentic/core/agent_card.py
+++ b/src/akgentic/core/agent_card.py
@@ -8,12 +8,110 @@ This ensures each agent gets an independent copy, preventing shared mutable stat
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast, get_args, get_origin
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.utils.serializer import SerializableBaseModel
+
+if TYPE_CHECKING:
+    pass
+
+
+# Cache for resolved ConfigType per agent class — walking __orig_bases__ is
+# non-trivial, and AgentCard.model_validate is hot on catalog load.
+_CONFIG_TYPE_CACHE: dict[type, type[BaseConfig] | None] = {}
+
+
+def _resolve_agent_class(value: str | type) -> type:
+    """Resolve ``agent_class`` (str FQCN or type) to the actual class.
+
+    Shared by ``AgentCard.get_agent_class()`` and the ``config`` coercion
+    model-validator.
+
+    Args:
+        value: Either a class object or a fully qualified dotted path string.
+
+    Returns:
+        The resolved class object.
+
+    Raises:
+        ValueError: If *value* is an empty string or not a dotted path.
+        ImportError / ModuleNotFoundError: If the module cannot be imported.
+        AttributeError: If the class is not found in the module.
+    """
+    if isinstance(value, type):
+        return value
+
+    if not value or "." not in value:
+        raise ValueError(
+            f"agent_class must be a fully qualified dotted path "
+            f"(e.g. 'mypackage.agents.MyAgent'), got: {value!r}"
+        )
+
+    components = value.split(".")
+    module_path = ".".join(components[:-1])
+    class_name = components[-1]
+
+    module = __import__(module_path, fromlist=[class_name])
+    return cast(type, getattr(module, class_name))
+
+
+def _extract_config_type(agent_cls: type) -> type[BaseConfig] | None:
+    """Walk ``agent_cls.__mro__`` for the first concrete ``Akgent[ConfigType, …]`` binding.
+
+    Inspects each base's ``__orig_bases__`` for an entry whose origin is
+    :class:`akgentic.core.agent.Akgent`. Returns the first type argument when
+    it is a concrete :class:`BaseConfig` subclass; returns ``None`` when the
+    argument is a :class:`typing.TypeVar` (unparameterised subclass), when
+    *agent_cls* is not an :class:`Akgent` subclass at all, or when no such
+    binding is found.
+
+    Results are memoised in ``_CONFIG_TYPE_CACHE`` keyed by *agent_cls*.
+
+    Args:
+        agent_cls: The candidate agent class.
+
+    Returns:
+        The concrete ``ConfigType`` (subclass of ``BaseConfig``) declared by the
+        first ``Akgent[X, Y]`` binding found in the MRO, or ``None`` when no
+        usable binding exists.
+    """
+    cached = _CONFIG_TYPE_CACHE.get(agent_cls)
+    if cached is not None or agent_cls in _CONFIG_TYPE_CACHE:
+        return cached
+
+    # Lazy import to avoid module-initialisation cycles: agent.py imports
+    # agent_card, and we cannot import Akgent at module top-level here.
+    from akgentic.core.agent import Akgent
+
+    if not (isinstance(agent_cls, type) and issubclass(agent_cls, Akgent)):
+        _CONFIG_TYPE_CACHE[agent_cls] = None
+        return None
+
+    config_type: type[BaseConfig] | None = None
+    for base_cls in agent_cls.__mro__:
+        orig_bases = getattr(base_cls, "__orig_bases__", ())
+        for orig in orig_bases:
+            if get_origin(orig) is not Akgent:
+                continue
+            args = get_args(orig)
+            if not args:
+                continue
+            candidate = args[0]
+            if isinstance(candidate, TypeVar):
+                # Unparameterised — keep searching up the MRO in case a
+                # sibling/parent provides a concrete binding.
+                continue
+            if isinstance(candidate, type) and issubclass(candidate, BaseConfig):
+                config_type = candidate
+                break
+        if config_type is not None:
+            break
+
+    _CONFIG_TYPE_CACHE[agent_cls] = config_type
+    return config_type
 
 
 class AgentCard(SerializableBaseModel):
@@ -58,6 +156,89 @@ class AgentCard(SerializableBaseModel):
     routes_to: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_config_to_agent_class_generic(cls, data: Any) -> Any:
+        """Coerce ``config`` to the concrete ``ConfigType`` declared by ``agent_class``.
+
+        Runs in ``mode="before"``, after ``SerializableBaseModel.deserialize_types``,
+        so *data* is a plain dict (if validating from raw payload) by the time we
+        see it. Leaves non-dict payloads and already-typed ``BaseConfig`` instances
+        untouched.
+
+        The resolution is intentionally tolerant:
+
+        * Unresolvable ``agent_class`` (empty string, bad FQCN) is left for the
+          field-level validator to report — we simply skip coercion in that case
+          so that the underlying ``ValueError`` / ``AttributeError`` raised by the
+          import path surfaces with its original message.
+        * ``_extract_config_type`` returning ``None`` (unparameterised class, or
+          a non-``Akgent`` class) falls back to the declared ``BaseConfig`` — the
+          field-level validator still produces a valid ``BaseConfig`` from the
+          input dict (AC #7).
+
+        Args:
+            data: Raw input passed to ``model_validate`` — typically a dict, but
+                Pydantic may pass a model instance when re-validating.
+
+        Returns:
+            The (possibly updated) input data. When coercion applies,
+            ``data["config"]`` is replaced with a concrete ``ConfigType``
+            instance; otherwise *data* is returned unchanged.
+
+        Raises:
+            ValueError: When ``agent_class`` is a string FQCN that cannot be
+                imported — re-raised as ``ValueError`` so Pydantic surfaces it
+                as a ``ValidationError`` (AC #8).
+        """
+        if not isinstance(data, dict):
+            return data
+
+        agent_class_raw = data.get("agent_class")
+        if agent_class_raw is None:
+            return data
+
+        # ``SerializableBaseModel.deserialize_types`` may not have run yet
+        # (Pydantic does not guarantee a parent-first ordering for
+        # ``mode="before"`` validators defined on the subclass). Accept the
+        # serialised ``{"__type__": "pkg.Class"}`` marker here as well so
+        # that round-trips through ``model_dump()``/``model_validate()``
+        # work unconditionally (AC #9).
+        if isinstance(agent_class_raw, dict) and "__type__" in agent_class_raw:
+            agent_class_raw = agent_class_raw["__type__"]
+
+        config_value = data.get("config")
+        # Already a BaseConfig instance → leave it alone (AC #3).
+        if isinstance(config_value, BaseConfig):
+            return data
+
+        # Only coerce dict config payloads; anything else is handed to the
+        # field-level validator unchanged.
+        if not isinstance(config_value, dict):
+            return data
+
+        try:
+            agent_cls = _resolve_agent_class(agent_class_raw)
+        except (ValueError, ImportError, AttributeError) as exc:
+            # AC #8: surface import errors as ValidationError via ValueError.
+            raise ValueError(
+                f"Could not resolve agent_class={agent_class_raw!r}: {exc}"
+            ) from exc
+
+        config_type = _extract_config_type(agent_cls)
+        if config_type is None or config_type is BaseConfig:
+            # AC #2 / AC #7: no-op when the generic resolves to BaseConfig or
+            # cannot be resolved — the declared annotation still applies.
+            return data
+
+        # Strip __model__ marker if the incoming dict tags itself as something
+        # different; model_validate on the concrete type will re-add its own.
+        # We only strip when it conflicts: if __model__ already names the
+        # target type (or a subclass), SerializableBaseModel.deserialize_types
+        # has already normalised things and we can pass the dict through.
+        data = {**data, "config": config_type.model_validate(config_value)}
+        return data
+
     def get_config_copy(self) -> BaseConfig:
         """Get a deep copy of the config as BaseConfig instance.
 
@@ -91,21 +272,7 @@ class AgentCard(SerializableBaseModel):
             ImportError: If the module cannot be imported.
             AttributeError: If the class is not found in the module.
         """
-        if isinstance(self.agent_class, type):
-            return self.agent_class
-
-        if not self.agent_class or "." not in self.agent_class:
-            raise ValueError(
-                f"agent_class must be a fully qualified dotted path "
-                f"(e.g. 'mypackage.agents.MyAgent'), got: {self.agent_class!r}"
-            )
-
-        components = self.agent_class.split(".")
-        module_path = ".".join(components[:-1])
-        class_name = components[-1]
-
-        module = __import__(module_path, fromlist=[class_name])
-        return cast(type, getattr(module, class_name))
+        return _resolve_agent_class(self.agent_class)
 
     def has_skill(self, skill: str) -> bool:
         """Check if this profile has a specific skill.

--- a/tests/core/test_agent_card.py
+++ b/tests/core/test_agent_card.py
@@ -34,12 +34,17 @@ class TestAgentCard:
         assert retrieved_config.name == "test"
 
     def test_create_agent_card_with_dict_config(self) -> None:
-        """AgentCard accepts dict config."""
+        """AgentCard accepts dict config.
+
+        Uses ``akgentic.core.Akgent`` (itself unparameterised) so the
+        config-coercion validator falls back to ``BaseConfig`` without
+        attempting to import a non-existent ``test.TestAgent`` module.
+        """
         card = AgentCard(
             role="TestAgent",
             description="A test agent",
             skills=["testing"],
-            agent_class="test.TestAgent",
+            agent_class="akgentic.core.Akgent",
             config={"name": "test", "role": "TestAgent"},
         )
 

--- a/tests/core/test_agent_card_config_coercion.py
+++ b/tests/core/test_agent_card_config_coercion.py
@@ -1,0 +1,282 @@
+"""Tests for AgentCard.config coercion to agent_class's declared ConfigType.
+
+These tests exercise the ``@model_validator(mode="before")`` on :class:`AgentCard`
+that walks ``agent_class.__orig_bases__`` to find a concrete ``Akgent[X, Y]``
+binding and coerces ``config`` accordingly (Story 9.1).
+
+All fixtures are defined **locally** in this module — ``akgentic-core`` must
+not import from ``akgentic.agent``, ``akgentic.catalog``, etc., so we cannot
+reach for ``akgentic.agent.BaseAgent``/``AgentConfig`` to test the real-world
+case. Instead we mirror those classes with typed subclasses here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.core import AgentCard, Akgent, BaseConfig
+from akgentic.core.agent_card import _CONFIG_TYPE_CACHE, _extract_config_type
+from akgentic.core.agent_state import BaseState
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror akgentic.agent.BaseAgent / AgentConfig locally.
+# ---------------------------------------------------------------------------
+
+
+class RichConfig(BaseConfig):
+    """Mirrors the shape of ``akgentic.agent.AgentConfig``.
+
+    Adds fields that are *not* on :class:`BaseConfig`, so that a silent
+    coercion to ``BaseConfig`` would drop them.
+    """
+
+    prompt: str = ""
+    model_name: str = ""
+    tools: list[str] = []
+
+
+class RichAgent(Akgent[RichConfig, BaseState]):
+    """Parameterised ``Akgent[RichConfig, BaseState]`` — the canonical case."""
+
+
+class DerivedRichAgent(RichAgent):
+    """Indirect inheritance — no new generic args; walker must recurse."""
+
+
+class CustomConfig(BaseConfig):
+    """User-defined config with an extra field."""
+
+    extra: str = ""
+
+
+class CustomAgent(Akgent[CustomConfig, BaseState]):
+    """User-defined agent binding its own ``CustomConfig``."""
+
+
+class GenericButNotAkgent[T: BaseConfig]:
+    """Unrelated generic class — validator must ignore it entirely."""
+
+
+class UnparameterisedAgent(Akgent):  # type: ignore[type-arg]
+    """Akgent subclass with no concrete type arguments — ConfigType unresolved."""
+
+
+# ---------------------------------------------------------------------------
+# Housekeeping — reset the module-level cache between tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_type_cache() -> None:
+    """Clear the memoisation cache so test ordering can't mask bugs."""
+    _CONFIG_TYPE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helper tests for _extract_config_type (unit-level).
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConfigType:
+    """Unit tests for the private ``_extract_config_type`` walker."""
+
+    def test_direct_generic_binding(self) -> None:
+        assert _extract_config_type(RichAgent) is RichConfig
+
+    def test_indirect_inheritance(self) -> None:
+        # DerivedRichAgent has no __orig_bases__ entry for Akgent[...]; the
+        # walker must climb the MRO and still find RichConfig (AC #5).
+        assert _extract_config_type(DerivedRichAgent) is RichConfig
+
+    def test_user_defined_config(self) -> None:
+        assert _extract_config_type(CustomAgent) is CustomConfig
+
+    def test_unparameterised_returns_none(self) -> None:
+        # AC #7: TypeVar args → treat as unresolved, not a hard error.
+        assert _extract_config_type(UnparameterisedAgent) is None
+
+    def test_non_akgent_class_returns_none(self) -> None:
+        # AC #7: not an Akgent subclass → None.
+        assert _extract_config_type(GenericButNotAkgent) is None
+        assert _extract_config_type(BaseConfig) is None
+
+    def test_result_is_cached(self) -> None:
+        _extract_config_type(RichAgent)
+        assert RichAgent in _CONFIG_TYPE_CACHE
+        assert _CONFIG_TYPE_CACHE[RichAgent] is RichConfig
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — AgentCard.model_validate path.
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardConfigCoercion:
+    """End-to-end tests for AgentCard config coercion via model validation."""
+
+    def test_string_agent_class_with_dict_config_coerces(self) -> None:
+        """AC #1, #4: string FQCN + dict config → RichConfig instance with all fields."""
+        fqcn = f"{RichAgent.__module__}.{RichAgent.__qualname__}"
+        card = AgentCard.model_validate(
+            {
+                "role": "Rich",
+                "description": "Rich agent",
+                "skills": [],
+                "agent_class": fqcn,
+                "config": {
+                    "name": "@rich",
+                    "role": "Rich",
+                    "prompt": "Be helpful.",
+                    "model_name": "gpt-x",
+                    "tools": ["t1", "t2"],
+                },
+            }
+        )
+        assert isinstance(card.config, RichConfig)
+        assert card.config.prompt == "Be helpful."
+        assert card.config.model_name == "gpt-x"
+        assert card.config.tools == ["t1", "t2"]
+
+    def test_class_agent_class_with_dict_config_coerces(self) -> None:
+        """AC #4: class object + dict config → RichConfig instance."""
+        card = AgentCard(
+            role="Rich",
+            description="Rich agent",
+            skills=[],
+            agent_class=RichAgent,
+            config={"name": "@rich", "role": "Rich", "prompt": "hi", "tools": []},  # type: ignore[arg-type]
+        )
+        assert isinstance(card.config, RichConfig)
+        assert card.config.prompt == "hi"
+
+    def test_human_proxy_no_op_stays_base_config(self) -> None:
+        """AC #2: generic resolves to BaseConfig → no coercion attempt, clean validation.
+
+        ``UserProxy(Akgent[BaseConfig, BaseState])`` mirrors the real-world
+        ``HumanProxy``. Construction with a plain dict must succeed and produce
+        a :class:`BaseConfig` instance without raising.
+        """
+        card = AgentCard.model_validate(
+            {
+                "role": "Human",
+                "description": "Human in the loop",
+                "skills": [],
+                "agent_class": "akgentic.core.UserProxy",
+                "config": {"name": "@Human", "role": "Human"},
+            }
+        )
+        assert type(card.config) is BaseConfig
+        assert card.config.name == "@Human"
+
+    def test_already_typed_config_passthrough(self) -> None:
+        """AC #3: passing a concrete RichConfig instance leaves it untouched."""
+        cfg = RichConfig(name="@rich", role="Rich", prompt="p", tools=["a"])
+        card = AgentCard(
+            role="Rich",
+            description="Rich agent",
+            skills=[],
+            agent_class=RichAgent,
+            config=cfg,
+        )
+        assert card.config is cfg or card.config == cfg
+        assert isinstance(card.config, RichConfig)
+        assert card.config.prompt == "p"
+
+    def test_indirect_inheritance_resolves_to_rich_config(self) -> None:
+        """AC #5: subclass with no new generics inherits RichConfig binding."""
+        fqcn = f"{DerivedRichAgent.__module__}.{DerivedRichAgent.__qualname__}"
+        card = AgentCard.model_validate(
+            {
+                "role": "Derived",
+                "description": "Derived rich agent",
+                "skills": [],
+                "agent_class": fqcn,
+                "config": {"name": "@d", "role": "Derived", "prompt": "hello"},
+            }
+        )
+        assert isinstance(card.config, RichConfig)
+        assert card.config.prompt == "hello"
+
+    def test_user_subclass_with_own_config_type(self) -> None:
+        """AC #6: CustomAgent bound to CustomConfig → coerces to CustomConfig."""
+        fqcn = f"{CustomAgent.__module__}.{CustomAgent.__qualname__}"
+        card = AgentCard.model_validate(
+            {
+                "role": "Custom",
+                "description": "Custom agent",
+                "skills": [],
+                "agent_class": fqcn,
+                "config": {"name": "@c", "role": "Custom", "extra": "hello"},
+            }
+        )
+        assert isinstance(card.config, CustomConfig)
+        assert card.config.extra == "hello"
+
+    def test_unparameterised_agent_no_op(self) -> None:
+        """AC #7: unparameterised Akgent subclass → validator no-op, dict becomes BaseConfig."""
+        fqcn = f"{UnparameterisedAgent.__module__}.{UnparameterisedAgent.__qualname__}"
+        card = AgentCard.model_validate(
+            {
+                "role": "Old",
+                "description": "Old agent",
+                "skills": [],
+                "agent_class": fqcn,
+                "config": {"name": "@old", "role": "Old"},
+            }
+        )
+        assert type(card.config) is BaseConfig
+        assert card.config.name == "@old"
+
+    def test_non_akgent_class_no_op(self) -> None:
+        """AC #7: non-Akgent agent_class → validator no-op, dict becomes BaseConfig."""
+        fqcn = f"{GenericButNotAkgent.__module__}.{GenericButNotAkgent.__qualname__}"
+        card = AgentCard.model_validate(
+            {
+                "role": "Weird",
+                "description": "Non-Akgent class",
+                "skills": [],
+                "agent_class": fqcn,
+                "config": {"name": "@weird", "role": "Weird"},
+            }
+        )
+        assert type(card.config) is BaseConfig
+        assert card.config.name == "@weird"
+
+    def test_unresolvable_agent_class_raises_validation_error(self) -> None:
+        """AC #8: bad FQCN + dict config surfaces via ValidationError naming the path."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentCard.model_validate(
+                {
+                    "role": "Bad",
+                    "description": "Bad FQCN",
+                    "skills": [],
+                    "agent_class": "not.a.real.module.Thing",
+                    "config": {"name": "@bad", "role": "Bad"},
+                }
+            )
+        assert "not.a.real.module.Thing" in str(exc_info.value)
+
+    def test_round_trip_model_dump_and_validate(self) -> None:
+        """AC #9: card.model_dump() → AgentCard.model_validate(...) preserves every field."""
+        original = AgentCard(
+            role="Rich",
+            description="Rich agent",
+            skills=["s1"],
+            agent_class=RichAgent,
+            config=RichConfig(
+                name="@rich",
+                role="Rich",
+                prompt="Be helpful.",
+                model_name="gpt-x",
+                tools=["t1"],
+            ),
+        )
+        dumped = original.model_dump()
+        restored = AgentCard.model_validate(dumped)
+        assert isinstance(restored.config, RichConfig)
+        assert restored.config.prompt == original.config.prompt  # type: ignore[attr-defined]
+        assert restored.config.model_name == original.config.model_name  # type: ignore[attr-defined]
+        assert restored.config.tools == original.config.tools  # type: ignore[attr-defined]
+        assert restored.role == original.role
+        assert restored.skills == original.skills


### PR DESCRIPTION
## Summary

`AgentCard.config` was pinned to the base `BaseConfig` annotation, so validating a YAML/dict payload against `agent_class=BaseAgent` silently dropped every `AgentConfig`-only field (`prompt`, `model_cfg`, `tools`, …). This PR co-locates the `agent_class -> config_class` invariant on `AgentCard` itself via a `@model_validator(mode="before")` that walks the class's generic parameters and coerces `config` to the right subclass before Pydantic binds the field schema.

- Adds `_resolve_agent_class(value)` helper shared with `AgentCard.get_agent_class()` — same import path for both the validator and the accessor.
- Adds `_extract_config_type(agent_cls)` that walks `__mro__` and each base's `__orig_bases__` (`typing.get_origin`/`get_args`) for the first concrete `Akgent[ConfigType, StateType]` binding. Returns `None` for `TypeVar` args, non-`Akgent` classes, or unparameterised subclasses. Results are memoised in a module-level cache.
- Adds `@model_validator(mode="before")` on `AgentCard` that coerces dict `config` to the resolved `ConfigType`, leaves concrete `BaseConfig` instances untouched, and re-raises `agent_class` import failures as `ValueError` (surfacing as a `ValidationError` naming the failing FQCN).
- Also handles the `{"__type__": "pkg.Class"}` serialised form of `agent_class` for unconditional `model_dump` -> `model_validate` round-trips.

## Module boundary

`akgentic-core` does not import `akgentic.agent.AgentConfig`. The walker resolves the class dynamically and reasons about it via `typing` primitives. Test fixtures mirror the shape of `akgentic.agent.BaseAgent`/`AgentConfig` locally.

## Tests

16 new tests in `tests/core/test_agent_card_config_coercion.py` cover every acceptance criterion (direct generic, indirect inheritance, user-defined config, `UserProxy` no-op, already-typed passthrough, unparameterised no-op, non-`Akgent` no-op, unresolvable FQCN error, round-trip). The pre-existing `test_create_agent_card_with_dict_config` was updated to pair its dict config with `akgentic.core.Akgent` (unparameterised — validator no-ops) so it no longer fails against the fake `test.TestAgent` FQCN.

Full suite: 464 passed, coverage 92.59% (agent_card.py 90%).

Closes #56