### PR TITLE
ci: add release workflow to publish wheel as GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.2.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Bump version in pyproject.toml
+        run: |
+          sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' pyproject.toml
+          grep '^version = ' pyproject.toml
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: release v${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
+          git push origin HEAD --tags
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ inputs.version }}"
+          name: "v${{ inputs.version }}"
+          files: dist/*.whl
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — manual `workflow_dispatch` with required `version` input
- Bumps `pyproject.toml`, commits + tags `vX.Y.Z`, builds wheel via `uv build`, creates GH Release with wheel attached
- Pilot for ADR-007: wheel distribution via per-submodule GitHub releases

Closes #60

## Validation
`workflow_dispatch` requires the workflow file on the default branch before it can be triggered, so end-to-end validation runs **after merge**:

1. Merge this PR
2. Trigger the workflow from the Actions tab with `version=1.0.0-alpha.2`
3. Verify the wheel lands on the releases page
4. `pip install` the downloaded wheel locally to confirm it's well-formed

If validation fails, revert; if it succeeds, replicate the file to the other seven akgentic submodules.