### PR TITLE
chore: bump version to 1.0.0-alpha.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Actor framework for building agent-based systems"
 readme = "README.md"
 authors = [

--- a/src/akgentic/core/__init__.py
+++ b/src/akgentic/core/__init__.py
@@ -30,7 +30,7 @@ from akgentic.core.agent_state import AkgentStateObserver, BaseState
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 from akgentic.core.user_proxy import UserProxy
 
-__version__ = "1.0.0-alpha.1"
+__version__ = "1.0.0-alpha.2"
 
 __all__ = [
     # Version

--- a/tests/core/test_package_init.py
+++ b/tests/core/test_package_init.py
@@ -7,15 +7,15 @@ import akgentic.core
 
 def test_package_version() -> None:
     """Test that package version is correctly set."""
-    assert akgentic.core.__version__ == "1.0.0-alpha.1"
+    assert akgentic.core.__version__ == "1.0.0-alpha.2"
 
 
 def test_package_metadata() -> None:
     """Test that package metadata is accessible."""
     metadata = importlib.metadata.metadata("akgentic")
     assert metadata["Name"] == "akgentic"
-    # Python normalizes "alpha.1" to "a1" in package version
-    assert metadata["Version"] == "1.0.0a1"
+    # Python normalizes "alpha.2" to "a2" in package version
+    assert metadata["Version"] == "1.0.0a2"
 
 
 def test_package_has_all_attribute() -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -38,7 +38,7 @@ class TestAkgenticNamespace:
     def test_version_accessible(self) -> None:
         from akgentic.core import __version__
 
-        assert __version__ == "1.0.0-alpha.1"
+        assert __version__ == "1.0.0-alpha.2"
 
     def test_message_types_not_in_all(self) -> None:
         import akgentic.core


### PR DESCRIPTION
Bumps pyproject.toml version 1.0.0-alpha.1 → 1.0.0-alpha.2 in lockstep with the other 7 akgentic submodules.

Closes #65