### PR TITLE
refactor: drop unused AgentCard.description field

### DIFF
--- a/examples/06_agent_cards.py
+++ b/examples/06_agent_cards.py
@@ -56,7 +56,7 @@ class CoordinatorAgent(Akgent):
         catalog = self.discover_catalog()
         print(f"[{self.config.name}] Found {len(catalog)} agent profiles:")
         for card in catalog:
-            print(f"  - {card.role}: {card.description}")
+            print(f"  - {card.role}")
             print(f"    Skills: {', '.join(card.skills)}")
             if card.routes_to:
                 print(f"    Routes to: {', '.join(card.routes_to)}")
@@ -68,7 +68,6 @@ class CoordinatorAgent(Akgent):
         research_profile = self.get_agent_card("ResearchAgent")
         if research_profile:
             print(f"[{self.config.name}] Found ResearchAgent:")
-            print(f"  Description: {research_profile.description}")
             print(f"  Skills: {research_profile.skills}")
             config = research_profile.get_config_copy()
             print(f"  Default config: name={config.name}, role={config.role}")

--- a/src/akgentic/core/agent_card.py
+++ b/src/akgentic/core/agent_card.py
@@ -121,7 +121,6 @@ class AgentCard(SerializableBaseModel):
 
     Example:
         >>> card = AgentCard(
-        ...     description="Performs web research and data gathering",
         ...     skills=["web_search", "pdf_extraction"],
         ...     agent_class="examples.multi_agent.ResearchAgent",
         ...     config=BaseConfig(name="research", role="ResearchAgent"),
@@ -137,7 +136,6 @@ class AgentCard(SerializableBaseModel):
         True
 
     Attributes:
-        description: Human-readable description of what this agent does
         skills: List of capabilities this agent provides
         agent_class: Fully qualified class name (str) or actual class (type) for instantiation
         config: Default BaseConfig (or subclass) for this profile — role lives here
@@ -150,9 +148,10 @@ class AgentCard(SerializableBaseModel):
         ``role`` is exposed as a ``@property`` that reads ``config.role`` — it is
         not a declared field. ``config.role`` is the single source of truth and
         must be non-empty; callers MUST set it via ``config=BaseConfig(role=...)``.
+        Human-readable description lives on the catalog ``Entry`` envelope, not
+        on the card payload.
     """
 
-    description: str
     skills: list[str]
     agent_class: str | type
     config: BaseConfig = Field(default_factory=BaseConfig)

--- a/tests/core/test_agent_card.py
+++ b/tests/core/test_agent_card.py
@@ -20,14 +20,12 @@ class TestAgentCard:
         """AgentCard can store config."""
         config = BaseConfig(name="test", role="TestAgent")
         card = AgentCard(
-            description="A test agent",
             skills=["testing", "validation"],
             agent_class="test.TestAgent",
             config=config,
         )
 
         assert card.role == "TestAgent"
-        assert card.description == "A test agent"
         assert "testing" in card.skills
         retrieved_config = card.get_config_copy()
         assert retrieved_config.name == "test"
@@ -247,7 +245,6 @@ class TestOrchestratorCatalog:
 
             # Register profile
             card = AgentCard(
-                description="Test agent",
                 skills=["testing"],
                 agent_class="test.TestAgent",
                 config=BaseConfig(name="test", role="TestAgent"),
@@ -258,7 +255,6 @@ class TestOrchestratorCatalog:
             retrieved = orch_proxy.get_agent_profile("TestAgent")
             assert retrieved is not None
             assert retrieved.role == "TestAgent"
-            assert retrieved.description == "Test agent"
         finally:
             system.shutdown()
 


### PR DESCRIPTION
## Summary

- Remove `description` from `AgentCard` in `src/akgentic/core/agent_card.py`.
- Update the docstring example and Attributes section.
- Fix two test assertions and one example print that introspected on the field.

The catalog `Entry` envelope already carries `description`, which is what every consumer reads — CLI listing, search filter, namespace export. The payload-level duplicate had no consumer. Removing it keeps the boundary clean: **card payloads carry behavior fields (skills, routes_to, config, agent_class); envelopes carry metadata (id, description)**.

Same shape as the change being landed in `b12consulting/akgentic-tool#168` (`ToolCard.name`/`description`).

Existing test fixtures that still pass `description="..."` keep working — `SerializableBaseModel` inherits Pydantic's default `extra="ignore"`, so the surplus kwarg is silently dropped. Fixture housekeeping and the YAML catalog cleanup under `data/catalog/agent-team*/agent/*.yaml` will land separately in the workspace repo.

Closes #67