### PR TITLE
fix(akgentic-core): 16-1 ActorSystemListener serializable address identity

### DIFF
--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -56,6 +56,11 @@ class ActorSystemListener(pykka.ThreadingActor):
         self._message_queue: deque[Any] = deque()
         self._waiters: deque[pykka.ThreadingFuture[Any]] = deque()
         self.agent_id = uuid.uuid4()
+        # Serializable address identity: the listener can appear as a Message
+        # sender (set by ExecutionContext.tell), so ActorAddressImpl.serialize()
+        # must resolve name/role/team_id/squad_id uniformly with ordinary actors.
+        self.team_id = uuid.uuid4()
+        self.config = BaseConfig(name="@ActorSystem", role="ActorSystem")
 
     def myAddress(self) -> ActorAddressImpl:  # noqa: N802
         """Get the address of this listener actor.

--- a/tests/core/test_actor_system_impl.py
+++ b/tests/core/test_actor_system_impl.py
@@ -188,6 +188,74 @@ class TestActorSystemListener:
 
         listener.stop()
 
+    def test_listener_address_serializes_to_actorsystem_identity(self) -> None:
+        """Listener address serializes without raising (AC #1, #2)."""
+        ctx = ExecutionContext()
+        address = ctx.myAddress
+
+        serialized = address.serialize()
+
+        assert serialized["name"] == "@ActorSystem"
+        assert serialized["role"] == "ActorSystem"
+        assert serialized["squad_id"] == ""
+        # team_id resolves to a well-formed UUID string, not an error
+        uuid.UUID(serialized["team_id"])
+        uuid.UUID(serialized["agent_id"])
+
+        ctx.shutdown()
+
+
+class TestListenerOriginSerialization:
+    """Tests for SentMessage whose sender is the internal listener (AC #1, #4)."""
+
+    def test_sent_message_from_listener_survives_snapshot(self) -> None:
+        """A SentMessage with a listener sender serializes via the orchestrator path."""
+        from akgentic.core.messages import SentMessage, UserMessage
+        from akgentic.core.orchestrator import Orchestrator
+
+        system = ActorSystem()
+        config = BaseConfig(name="recipient", role="Tester")
+        recipient = system.createActor(SimpleAgent, config=config)
+
+        ctx = ExecutionContext()
+        # tell() stamps message.sender with the listener address.
+        sent = SentMessage(message=UserMessage(content="hi"), recipient=recipient)
+        ctx.tell(recipient, sent)
+
+        # snapshot_for_subscribers must NOT raise on the listener-origin sender.
+        snapshot = Orchestrator.snapshot_for_subscribers(sent)
+        sender_dict = snapshot.sender.serialize()  # type: ignore[union-attr]
+
+        assert sender_dict["name"] == "@ActorSystem"
+        assert sender_dict["role"] == "ActorSystem"
+
+        ctx.shutdown()
+        system.shutdown()
+
+    def test_ordinary_actor_address_serialization_unchanged(self) -> None:
+        """An ordinary actor's address still serializes to the expected shape (AC #3)."""
+        system = ActorSystem()
+        config = BaseConfig(name="ordinary-agent", role="Worker")
+        address = system.createActor(SimpleAgent, config=config)
+
+        serialized = cast(ActorAddressImpl, address).serialize()
+
+        assert serialized["__actor_address__"] is True
+        assert serialized["name"] == "ordinary-agent"
+        assert serialized["role"] == "Worker"
+        assert set(serialized.keys()) == {
+            "__actor_address__",
+            "__actor_type__",
+            "agent_id",
+            "name",
+            "role",
+            "team_id",
+            "squad_id",
+            "user_message",
+        }
+
+        system.shutdown()
+
 
 class TestActorSystemEdgeCases:
     """Edge case tests for ActorSystem."""


### PR DESCRIPTION
## Summary

Story 16-1 — gives the internal `ActorSystemListener` a serializable address identity.

`ActorSystemListener` was a plain `pykka.ThreadingActor` with no `config` and no
`team_id` attribute. `ExecutionContext.tell()` unconditionally stamps every
`Message.sender` with `ActorAddressImpl(listener_ref)`, so any `SentMessage`
announced through the orchestrator crashed the subscriber-broadcast path:
`Orchestrator.snapshot_for_subscribers` → `ActorAddressImpl.serialize()` raised
`AttributeError` while reading `actor.config` (and would also fail resolving
`team_id`).

## Defect resolved

The fix is purely additive on `ActorSystemListener.__init__`:

- `team_id = uuid.uuid4()` so `ActorAddressImpl.team_id` resolves.
- `config = BaseConfig(name="@ActorSystem", role="ActorSystem")` so
  `name`/`role`/`squad_id` resolve uniformly with every ordinary actor.

`ActorAddressImpl` and `actor_address_impl.py` are untouched, so ordinary-actor
serialization is byte-for-byte unchanged. The listener address now serializes to
a stable `@ActorSystem` / `ActorSystem` identity.

## Tests

Three tests added in `tests/core/test_actor_system_impl.py`:
- `test_listener_address_serializes_to_actorsystem_identity` — AC #1, #2.
- `test_sent_message_from_listener_survives_snapshot` — AC #1, #4: a `SentMessage`
  with a listener sender survives `Orchestrator.snapshot_for_subscribers`.
- `test_ordinary_actor_address_serialization_unchanged` — AC #3 regression guard.

Full suite: 473 passed. `mypy packages/akgentic-core/src/` — Success.
`ruff check packages/akgentic-core/src/` — clean.

## Downstream

Unblocks `akgentic-team` ADR-17 (Team Welcome Message) / Epic 20 Story 20-2, which
announces a `SentMessage` through the orchestrator and was blocked on this fix.

Closes #69
Relates to #69
