### PR TITLE
feat(akgentic-core): epic 17 — EventSubscriber team_id-Aware Lifecycle Hooks & Unsubscribe Reversal (17.1 → 17.3)

### DIFF
--- a/examples/05_multi_agent.py
+++ b/examples/05_multi_agent.py
@@ -16,6 +16,7 @@ Or with:  uv run python examples/05_multi_agent.py
 from __future__ import annotations
 
 import time
+import uuid
 from typing import TYPE_CHECKING
 
 from akgentic.core import (
@@ -408,15 +409,15 @@ class SimpleLogger(EventSubscriber):
         """
         self.message_count += 1
 
-    def set_restoring(self, restoring: bool) -> None:
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:
         """No-op — this simple logger doesn't need to handle restoring."""
         pass
 
-    def on_stop_request(self) -> None:
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
         """No-op — stop handling is bridged by TimerStopSubscriber in akgentic-team."""
         pass
 
-    def on_stop(self) -> None:
+    def on_stop(self, team_id: uuid.UUID) -> None:
         """Called when orchestrator stops."""
         pass
 

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -244,6 +244,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
     def on_stop(self) -> None:
         self._notify_subscribers_lifecycle("on_stop", self.team_id)
         super().on_stop()
+        self.subscribers.clear()
         logger.info(f">>> [{self.config.name}] Stopped !")
 
     @override

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -8,6 +8,7 @@ message flows, and state changes using in-memory storage.
 import logging
 import os
 import threading
+import uuid
 from collections.abc import Callable
 from typing import Any, Protocol, override
 
@@ -111,7 +112,7 @@ class EventSubscriber(Protocol):
         - PostgresEventSubscriber: Persists events to PostgreSQL
     """
 
-    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
         """Toggle restore-replay guard.
 
         Called by ``TeamManager.resume_team()`` before and after replaying
@@ -119,22 +120,33 @@ class EventSubscriber(Protocol):
         skip processing during restore. Default implementation is a no-op.
 
         Args:
+            team_id: ``team_id`` of the orchestrator triggering the notification,
+                enabling per-team routing on shared subscriber instances.
             restoring: ``True`` when replay starts, ``False`` when it ends.
         """
         ...
 
-    def on_stop_request(self) -> None:
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
         """Called when an orchestrator makes a stop request (e.g. inactivity timer fires).
 
         Default implementation is a no-op — subscribers (e.g. ``TimerStopSubscriber``
         in ``akgentic-team``) override this to decide how to actually stop the
         team. The orchestrator itself does NOT stop on this signal; shutdown is
         the subscriber's responsibility.
+
+        Args:
+            team_id: ``team_id`` of the orchestrator triggering the notification,
+                enabling per-team routing on shared subscriber instances.
         """
         ...
 
-    def on_stop(self) -> None:
-        """Called when an orchestrator stops."""
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        """Called when an orchestrator stops.
+
+        Args:
+            team_id: ``team_id`` of the orchestrator triggering the notification,
+                enabling per-team routing on shared subscriber instances.
+        """
         ...
 
     def on_message(self, msg: Message) -> None:
@@ -230,7 +242,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
     @override
     def on_stop(self) -> None:
-        self._notify_subscribers("on_stop")
+        self._notify_subscribers("on_stop", team_id=self.team_id)
         super().on_stop()
         logger.info(f">>> [{self.config.name}] Stopped !")
 
@@ -249,7 +261,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         """
         team_id = self.team_id
         logger.info(f"Orchestrator timeout after {self._timer.delay}s inactivity (team={team_id})")
-        self._notify_subscribers("on_stop_request")
+        self._notify_subscribers("on_stop_request", team_id=team_id)
 
     def get_timer(self) -> Timer:
         """Return the inactivity Timer instance (for testing and introspection).
@@ -290,22 +302,36 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
         return snapshot_addresses(message)  # type: ignore[return-value]
 
-    def _notify_subscribers(self, event_method: str, message: Message | None = None) -> None:
+    def _notify_subscribers(
+        self,
+        event_method: str,
+        message: Message | None = None,
+        *,
+        team_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Unified subscriber notification with fault tolerance.
 
         Args:
-            event_method: Name of the subscriber method to call
-            message: Message to pass to subscriber
+            event_method: Name of the subscriber method to call.
+            message: Message to pass to subscriber (``on_message`` dispatch).
+            team_id: When set, dispatch as a lifecycle call
+                (``set_restoring``, ``on_stop_request``, ``on_stop``) with
+                ``team_id`` as the first positional argument.
+            **kwargs: Extra kwargs forwarded to the lifecycle method
+                (e.g. ``restoring=True`` for ``set_restoring``).
         """
         if message is not None:
             message = self.snapshot_for_subscribers(message)
         for subscriber in self.subscribers:
             try:
                 method = getattr(subscriber, event_method)
-                if message is None:
-                    method()
-                else:
+                if team_id is not None:
+                    method(team_id, **kwargs)
+                elif message is not None:
                     method(message)
+                else:
+                    method()
             except Exception as e:
                 logger.error(
                     f"Subscriber {subscriber.__class__.__name__} failed {event_method}: {e}"

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -196,6 +196,31 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         ... )
         >>> # Agents automatically send telemetry to orchestrator
         >>> messages = orchestrator_ref.get_messages().get()
+
+    Load-bearing assumption — Pykka mailbox drain on self-stop:
+        When an ``Orchestrator`` (or any ``Akgent``) calls ``self.stop()`` from
+        inside one of its own ``receiveMsg_*`` handlers — the canonical shape
+        every ``orchestrator_proxy.stop()`` graceful-stop call drives via
+        ``Akgent.receiveMsg_StopRecursively`` → ``self.stop()`` — Pykka
+        guarantees that the actor's mailbox is fully drained before ``on_stop``
+        fires. Every queued message is processed to completion first;
+        ``on_stop`` runs exactly once, afterwards.
+
+        The dispatch path this invariant protects is
+        ``self._notify_subscribers_lifecycle("on_stop", self.team_id)``, called
+        from ``Orchestrator.on_stop`` BEFORE ``super().on_stop()``. Downstream
+        subscribers (``RedisStreamSubscriber.on_stop`` and the rest of the
+        master cross-package ADR-024 chain — see also package-local ADR-011)
+        rely on the invariant: without it, an ``on_message`` → ``XADD`` could
+        land *after* ``on_stop`` → ``DEL`` and resurface the very race ADR-024
+        eliminates.
+
+        Verification test:
+        ``packages/akgentic-core/tests/core/test_pykka_mailbox_drain_on_self_stop.py``
+        — ``test_pykka_drains_mailbox_before_on_stop_on_self_stop``. If a
+        future Pykka upgrade regresses this guarantee, that test fails and
+        surfaces the regression before the master ADR-024 chain breaks in
+        production.
     """
 
     @override

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -242,7 +242,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
     @override
     def on_stop(self) -> None:
-        self._notify_subscribers("on_stop", team_id=self.team_id)
+        self._notify_subscribers_lifecycle("on_stop", self.team_id)
         super().on_stop()
         logger.info(f">>> [{self.config.name}] Stopped !")
 
@@ -261,7 +261,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         """
         team_id = self.team_id
         logger.info(f"Orchestrator timeout after {self._timer.delay}s inactivity (team={team_id})")
-        self._notify_subscribers("on_stop_request", team_id=team_id)
+        self._notify_subscribers_lifecycle("on_stop_request", team_id)
 
     def get_timer(self) -> Timer:
         """Return the inactivity Timer instance (for testing and introspection).
@@ -302,37 +302,53 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
         return snapshot_addresses(message)  # type: ignore[return-value]
 
-    def _notify_subscribers(
-        self,
-        event_method: str,
-        message: Message | None = None,
-        *,
-        team_id: uuid.UUID | None = None,
-        **kwargs: Any,
-    ) -> None:
-        """Unified subscriber notification with fault tolerance.
+    def _notify_subscribers_message(self, event_method: str, message: Message) -> None:
+        """Dispatch an ``on_message`` notification (the only message-bearing hook).
+
+        Snapshots actor addresses on the caller thread, then fans out to every
+        subscriber. Per-subscriber exceptions are caught and logged so a single
+        faulty subscriber cannot block the rest of the dispatch chain.
 
         Args:
-            event_method: Name of the subscriber method to call.
-            message: Message to pass to subscriber (``on_message`` dispatch).
-            team_id: When set, dispatch as a lifecycle call
-                (``set_restoring``, ``on_stop_request``, ``on_stop``) with
-                ``team_id`` as the first positional argument.
+            event_method: Name of the message-bearing subscriber method to call
+                (today: ``"on_message"``).
+            message: Message to forward to every subscriber after snapshotting.
+        """
+        snapshot = self.snapshot_for_subscribers(message)
+        for subscriber in self.subscribers:
+            try:
+                getattr(subscriber, event_method)(snapshot)
+            except Exception as e:  # noqa: BLE001
+                logger.error(
+                    f"Subscriber {subscriber.__class__.__name__} failed {event_method}: {e}"
+                )
+
+    def _notify_subscribers_lifecycle(
+        self,
+        event_method: str,
+        team_id: uuid.UUID,
+        **kwargs: Any,
+    ) -> None:
+        """Dispatch a lifecycle notification (``set_restoring``, ``on_stop_request``, ``on_stop``).
+
+        Every lifecycle hook carries ``team_id`` as its first positional
+        argument so shared subscribers (one instance attached to N teams on a
+        worker) can route cleanup per-team. Additional keyword arguments are
+        forwarded to the subscriber method (e.g. ``restoring=True`` for
+        ``set_restoring``). Per-subscriber exceptions are caught and logged so
+        a single faulty subscriber cannot block the rest of the dispatch chain.
+
+        Args:
+            event_method: Name of the lifecycle subscriber method to call.
+            team_id: ``team_id`` of the orchestrator triggering the notification,
+                passed as the first positional argument to the subscriber method.
             **kwargs: Extra kwargs forwarded to the lifecycle method
                 (e.g. ``restoring=True`` for ``set_restoring``).
         """
-        if message is not None:
-            message = self.snapshot_for_subscribers(message)
         for subscriber in self.subscribers:
             try:
-                method = getattr(subscriber, event_method)
-                if team_id is not None:
-                    method(team_id, **kwargs)
-                elif message is not None:
-                    method(message)
-                else:
-                    method()
-            except Exception as e:
+                getattr(subscriber, event_method)(team_id, **kwargs)
+            except Exception as e:  # noqa: BLE001
                 logger.error(
                     f"Subscriber {subscriber.__class__.__name__} failed {event_method}: {e}"
                 )
@@ -346,7 +362,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         """
         self.messages.append(message)
         self._current_team_members = None  # Clear cache
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_StopMessage(self, message: StopMessage, sender: ActorAddress) -> None:
         """Handle agent stop events.
@@ -363,7 +379,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
         self.messages.append(message)
         self._current_team_members = None  # Clear cache
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_SentMessage(self, message: SentMessage, sender: ActorAddress) -> None:
         """Handle message sent events.
@@ -376,7 +392,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         if sender == self.myAddress:
             return
         self.messages.append(message)
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_ReceivedMessage(self, message: ReceivedMessage, sender: ActorAddress) -> None:
         """Handle message received events.
@@ -390,7 +406,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             return
         self._timer.task_started()
         self.messages.append(message)
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_ProcessedMessage(self, message: ProcessedMessage, sender: ActorAddress) -> None:
         """Handle message processed events.
@@ -404,7 +420,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             return
         self._timer.task_completed()
         self.messages.append(message)
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_ErrorMessage(self, message: ErrorMessage, sender: ActorAddress) -> None:
         """Handle error events.
@@ -417,7 +433,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         if sender == self.myAddress:
             return
         self.messages.append(message)
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_StateChangedMessage(
         self, message: StateChangedMessage, sender: ActorAddress
@@ -429,7 +445,7 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             sender: ActorAddress of sending agent
         """
         self.state_dict[str(sender.agent_id)] = message.state
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_EventMessage(self, message: EventMessage, sender: ActorAddress) -> None:
         """Handle agent event message.
@@ -439,21 +455,21 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             sender: ActorAddress of sending agent
         """
         self.messages.append(message)
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def restore_message(self, message: Message) -> None:
         """Replay a single persisted event during team restoration.
 
         Appends the message to ``self.messages`` so that ``get_team()`` and
         other history-based queries work correctly after restore, then
-        dispatches to all subscribers via ``_notify_subscribers``.
+        dispatches to all subscribers via ``_notify_subscribers_message``.
 
         Args:
             message: The persisted message to replay.
         """
         self.messages.append(message)
         self._current_team_members = None  # Invalidate cache
-        self._notify_subscribers("on_message", message)
+        self._notify_subscribers_message("on_message", message)
 
     def end_restoration(self) -> None:
         """Signal that restoration replay is complete.

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -963,7 +963,7 @@ class TestSnapshotForSubscribers:
 
 
 # ---------------------------------------------------------------------------
-# Story 17.1 — team_id propagation through _notify_subscribers
+# Story 17.1 — team_id propagation through _notify_subscribers_lifecycle
 # ---------------------------------------------------------------------------
 
 
@@ -988,31 +988,31 @@ class _LifecycleRaisingSubscriber:
 
 
 class _NotifyExposingOrchestrator(Orchestrator):
-    """Orchestrator subclass that exposes ``_notify_subscribers`` to Pykka proxies.
+    """Orchestrator subclass that exposes the notify helpers to Pykka proxies.
 
     Pykka's proxy filters out underscore-prefixed methods, so tests that need
-    to drive ``_notify_subscribers`` directly (lifecycle dispatch in
+    to drive ``_notify_subscribers_lifecycle`` directly (lifecycle dispatch in
     Story 17.1 — there is no in-source caller for ``set_restoring``) cannot
     invoke it through ``system.proxy_ask(...)``. This thin wrapper exposes
-    the helper under a public name without changing production semantics.
+    each helper under a public name without changing production semantics.
     """
 
-    def notify_subscribers(
+    def notify_subscribers_lifecycle(
         self,
         event_method: str,
-        message: Message | None = None,
-        *,
-        team_id: uuid.UUID | None = None,
+        team_id: uuid.UUID,
         **kwargs: Any,
     ) -> None:
-        """Public façade over ``_notify_subscribers`` for proxy-driven tests."""
-        self._notify_subscribers(
-            event_method, message, team_id=team_id, **kwargs
-        )
+        """Public façade over ``_notify_subscribers_lifecycle`` for proxy-driven tests."""
+        self._notify_subscribers_lifecycle(event_method, team_id, **kwargs)
+
+    def notify_subscribers_message(self, event_method: str, message: Message) -> None:
+        """Public façade over ``_notify_subscribers_message`` for proxy-driven tests."""
+        self._notify_subscribers_message(event_method, message)
 
 
 class TestNotifySubscribersTeamIdPropagation:
-    """Story 17.1 — `_notify_subscribers` propagates team_id to lifecycle hooks."""
+    """Story 17.1 — `_notify_subscribers_lifecycle` propagates team_id to lifecycle hooks."""
 
     def test_set_restoring_passes_team_id_to_subscribers(self) -> None:
         """AC #2: lifecycle dispatch forwards team_id + restoring=True."""
@@ -1027,7 +1027,7 @@ class TestNotifySubscribersTeamIdPropagation:
         orch_proxy.subscribe(sub)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("set_restoring", team_id=orch_team_id, restoring=True)
+        orch_proxy.notify_subscribers_lifecycle("set_restoring", orch_team_id, restoring=True)
 
         assert sub.restoring_calls == [(orch_team_id, True)]
         assert sub.restoring is True
@@ -1035,7 +1035,7 @@ class TestNotifySubscribersTeamIdPropagation:
         system.shutdown()
 
     def test_on_stop_request_passes_team_id_to_subscribers(self) -> None:
-        """AC #3: `_notify_subscribers("on_stop_request", team_id=...)` forwards team_id."""
+        """AC #3: `_notify_subscribers_lifecycle("on_stop_request", team_id)` forwards team_id."""
         system = ActorSystem()
         orch_addr = system.createActor(
             _NotifyExposingOrchestrator,
@@ -1047,18 +1047,18 @@ class TestNotifySubscribersTeamIdPropagation:
         orch_proxy.subscribe(sub)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("on_stop_request", team_id=orch_team_id)
+        orch_proxy.notify_subscribers_lifecycle("on_stop_request", orch_team_id)
 
         assert sub.stop_request_team_ids == [orch_team_id]
 
         system.shutdown()
 
     def test_on_stop_passes_team_id_to_subscribers(self) -> None:
-        """AC #1: `_notify_subscribers("on_stop", team_id=...)` forwards team_id.
+        """AC #1: `_notify_subscribers_lifecycle("on_stop", team_id)` forwards team_id.
 
-        Exercises the call directly via `_notify_subscribers` (not the full
-        Pykka stop() path) so the test isolates the signature change in 17.1
-        from the body-reordering 17.2 will deliver.
+        Exercises the call directly via `_notify_subscribers_lifecycle` (not
+        the full Pykka stop() path) so the test isolates the signature change
+        in 17.1 from the body-reordering 17.2 will deliver.
         """
         system = ActorSystem()
         orch_addr = system.createActor(
@@ -1071,7 +1071,7 @@ class TestNotifySubscribersTeamIdPropagation:
         orch_proxy.subscribe(sub)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("on_stop", team_id=orch_team_id)
+        orch_proxy.notify_subscribers_lifecycle("on_stop", orch_team_id)
 
         assert sub.stop_team_ids == [orch_team_id]
         assert sub.stopped is True
@@ -1118,7 +1118,7 @@ class TestLifecycleFanOutFaultIsolation:
         orch_proxy.subscribe(third)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("set_restoring", team_id=orch_team_id, restoring=False)
+        orch_proxy.notify_subscribers_lifecycle("set_restoring", orch_team_id, restoring=False)
 
         assert first.restoring_calls == [(orch_team_id, False)]
         assert third.restoring_calls == [(orch_team_id, False)]
@@ -1143,7 +1143,7 @@ class TestLifecycleFanOutFaultIsolation:
         orch_proxy.subscribe(third)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("on_stop_request", team_id=orch_team_id)
+        orch_proxy.notify_subscribers_lifecycle("on_stop_request", orch_team_id)
 
         assert first.stop_request_team_ids == [orch_team_id]
         assert third.stop_request_team_ids == [orch_team_id]
@@ -1168,7 +1168,7 @@ class TestLifecycleFanOutFaultIsolation:
         orch_proxy.subscribe(third)
 
         orch_team_id = orch_addr.team_id
-        orch_proxy.notify_subscribers("on_stop", team_id=orch_team_id)
+        orch_proxy.notify_subscribers_lifecycle("on_stop", orch_team_id)
 
         assert first.stop_team_ids == [orch_team_id]
         assert third.stop_team_ids == [orch_team_id]
@@ -1177,7 +1177,7 @@ class TestLifecycleFanOutFaultIsolation:
 
 
 class TestOnMessageDispatchUnchanged:
-    """AC #5: `_notify_subscribers("on_message", message)` still dispatches as before."""
+    """AC #5: `_notify_subscribers_message("on_message", message)` still dispatches as before."""
 
     def test_on_message_does_not_receive_team_id(self) -> None:
         """Message dispatch passes the snapshotted message and NO team_id kwarg."""

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1201,3 +1201,169 @@ class TestOnMessageDispatchUnchanged:
         assert sub.restoring_calls == []
 
         system.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Story 17.2 — Orchestrator.on_stop fan-out before clear (ADR-011 §3)
+# ---------------------------------------------------------------------------
+
+
+class _LenAtStopRecorder:
+    """Subscriber that snapshots ``len(subscribers)`` at the moment ``on_stop`` fires.
+
+    Used to verify AC #1 — the subscriber is still attached to the orchestrator
+    when its ``on_stop`` body executes (i.e. fan-out runs BEFORE
+    ``self.subscribers.clear()``).
+    """
+
+    def __init__(self) -> None:
+        self.subscribers_list_ref: list[EventSubscriber] | None = None
+        self.calls: list[tuple[uuid.UUID, int]] = []
+
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
+        pass
+
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
+        pass
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        # Capture len() at the moment fan-out fires. AC #1 requires this to be
+        # ≥ 1 (subscriber is still attached when its on_stop runs).
+        snapshot = len(self.subscribers_list_ref) if self.subscribers_list_ref is not None else -1
+        self.calls.append((team_id, snapshot))
+
+    def on_message(self, msg: Message) -> None:
+        pass
+
+
+class _OnStopRaisingSubscriber:
+    """Subscriber whose ``on_stop`` raises; other hooks are no-ops.
+
+    Used to verify AC #4 — a raising subscriber does not block the post-stop
+    invariants (``super().on_stop()`` still runs, ``subscribers.clear()`` still
+    runs, ``Stopped !`` log line still runs).
+    """
+
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
+        pass
+
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
+        pass
+
+    def on_stop(self, team_id: uuid.UUID) -> Never:
+        raise RuntimeError("boom")
+
+    def on_message(self, msg: Message) -> None:
+        pass
+
+
+class TestOnStopFanOutThenClear:
+    """Story 17.2 — Orchestrator.on_stop fans out THEN clears subscribers.
+
+    Behavioural invariants under test (ACs #1–#5):
+
+    - Fan-out fires while the subscriber is still attached (snapshot
+      ``len(subscribers) >= 1`` from inside ``on_stop``).
+    - ``team_id`` passed to ``on_stop`` is the orchestrator's own ``team_id``.
+    - ``subscribers`` list is empty after ``on_stop`` returns.
+    - A subscriber raising in ``on_stop`` does not block ``clear()`` running.
+    - Three-subscriber fault isolation contract from 17.1 is preserved (first
+      and third still receive their call when the middle one raises).
+    """
+
+    def test_on_stop_fan_out_before_clear_then_list_empty(self) -> None:
+        """AC #1, #2, #3: fan-out runs while attached; subscribers list cleared after stop."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        recorder = _LenAtStopRecorder()
+        orch_proxy.subscribe(recorder)
+
+        # Capture the live subscribers-list reference BEFORE stop so we can
+        # observe the post-stop ``clear()`` via the same Python list object.
+        subscribers_list = orch_proxy.subscribers
+        recorder.subscribers_list_ref = subscribers_list
+        assert recorder in subscribers_list
+
+        orch_team_id = orch_addr.team_id
+
+        # Trigger the real on_stop via the system shutdown path.
+        system.shutdown()
+
+        # AC #1: fan-out fired exactly once, with the orchestrator's team_id,
+        # and the subscriber was still attached at the moment of the call.
+        assert len(recorder.calls) == 1
+        recorded_team_id, len_at_fan_out = recorder.calls[0]
+        assert recorded_team_id == orch_team_id
+        assert len_at_fan_out >= 1
+
+        # AC #2 + AC #3: subscribers list cleared after on_stop returned.
+        assert subscribers_list == []
+
+    def test_on_stop_raising_subscriber_does_not_block_clear(self) -> None:
+        """AC #4: clear() still runs and recorder still fires when a sibling raises."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        recorder = _LenAtStopRecorder()
+        failing = _OnStopRaisingSubscriber()
+        orch_proxy.subscribe(recorder)
+        orch_proxy.subscribe(failing)
+
+        subscribers_list = orch_proxy.subscribers
+        recorder.subscribers_list_ref = subscribers_list
+
+        # Stop the orchestrator. The failing subscriber raises inside
+        # ``_notify_subscribers_lifecycle`` but its per-subscriber try/except
+        # (landed in 17.1) swallows it — fan-out completes for the recorder,
+        # ``super().on_stop()`` runs, and ``clear()`` runs unconditionally.
+        system.shutdown()  # MUST NOT raise
+
+        # Recorder still received its call exactly once.
+        assert len(recorder.calls) == 1
+
+        # AC #4: ``clear()`` ran even though one subscriber raised.
+        assert subscribers_list == []
+
+    def test_on_stop_three_subscribers_middle_raises(self) -> None:
+        """AC #5: first and third still receive on_stop when the middle one raises."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        first = _LenAtStopRecorder()
+        middle = _OnStopRaisingSubscriber()
+        third = _LenAtStopRecorder()
+
+        orch_proxy.subscribe(first)
+        orch_proxy.subscribe(middle)
+        orch_proxy.subscribe(third)
+
+        subscribers_list = orch_proxy.subscribers
+        first.subscribers_list_ref = subscribers_list
+        third.subscribers_list_ref = subscribers_list
+
+        orch_team_id = orch_addr.team_id
+
+        system.shutdown()
+
+        # AC #5: both recorders received their call exactly once with the
+        # orchestrator's own team_id (fault-isolation from 17.1 preserved).
+        assert len(first.calls) == 1
+        assert len(third.calls) == 1
+        assert first.calls[0][0] == orch_team_id
+        assert third.calls[0][0] == orch_team_id
+
+        # AC #4 redux: clear() still ran post-stop.
+        assert subscribers_list == []

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,8 +1,9 @@
 """Tests for Orchestrator agent."""
 
+import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Never
+from typing import Any, Never
 
 import pykka
 import pytest
@@ -258,25 +259,34 @@ class RecordingSubscriber:
     """Subscriber that records on_message calls for restore tests.
 
     Implements the full EventSubscriber protocol: on_message, on_stop,
-    set_restoring.
+    on_stop_request, set_restoring (all team_id-aware).
     """
 
     def __init__(self) -> None:
         self.messages: list[Message] = []
         self.stopped: bool = False
         self.restoring: bool = False
+        self.stop_team_ids: list[uuid.UUID] = []
+        self.stop_request_team_ids: list[uuid.UUID] = []
+        self.restoring_calls: list[tuple[uuid.UUID, bool]] = []
 
-    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
         """Track restore-replay guard state."""
         self.restoring = restoring
+        self.restoring_calls.append((team_id, restoring))
 
     def on_message(self, msg: Message) -> None:
         """Record received message."""
         self.messages.append(msg)
 
-    def on_stop(self) -> None:
+    def on_stop(self, team_id: uuid.UUID) -> None:
         """Record stop."""
         self.stopped = True
+        self.stop_team_ids.append(team_id)
+
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
+        """Record stop request."""
+        self.stop_request_team_ids.append(team_id)
 
 
 class TestUnsubscribe:
@@ -408,7 +418,6 @@ class UsageEvent:
     """Test event type for usage tracking."""
 
     tokens: int
-
 
 
 class TestEventMessagePersistence:
@@ -707,8 +716,7 @@ class TestGetChildrenOrCreate:
         # (both calls should have resulted in only one StartMessage for #Bar)
         messages = proxy.get_messages()
         bar_starts = [
-            m for m in messages
-            if isinstance(m, StartMessage) and m.config.name == "#Bar"
+            m for m in messages if isinstance(m, StartMessage) and m.config.name == "#Bar"
         ]
         assert len(bar_starts) == 1
 
@@ -723,12 +731,8 @@ class TestGetChildrenOrCreate:
         )
         proxy = system.proxy_ask(orch_addr, Orchestrator)
 
-        foo = proxy.getChildrenOrCreate(
-            SimpleAgent, config=BaseConfig(name="#Foo", role="Worker")
-        )
-        bar = proxy.getChildrenOrCreate(
-            SimpleAgent, config=BaseConfig(name="#Bar", role="Worker")
-        )
+        foo = proxy.getChildrenOrCreate(SimpleAgent, config=BaseConfig(name="#Foo", role="Worker"))
+        bar = proxy.getChildrenOrCreate(SimpleAgent, config=BaseConfig(name="#Bar", role="Worker"))
 
         assert foo.agent_id != bar.agent_id
         assert foo.name == "#Foo"
@@ -772,9 +776,7 @@ class TestSnapshotForSubscribers:
         # Subscriber should have received one message (excluding orchestrator's own)
         # Find the message dispatched for our test agent
         sub_msgs = [
-            m
-            for m in sub.messages
-            if isinstance(m, StartMessage) and m.config.name == "test-agent"
+            m for m in sub.messages if isinstance(m, StartMessage) and m.config.name == "test-agent"
         ]
         assert len(sub_msgs) == 1
 
@@ -956,5 +958,246 @@ class TestSnapshotForSubscribers:
         ]
         assert len(internal_starts) == 1
         assert isinstance(internal_starts[0].parent, ActorAddressImpl)
+
+        system.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Story 17.1 — team_id propagation through _notify_subscribers
+# ---------------------------------------------------------------------------
+
+
+class _LifecycleRaisingSubscriber:
+    """Subscriber whose lifecycle hooks raise to exercise fault-isolation.
+
+    on_message is a no-op so we can place this subscriber in the dispatch
+    chain without interfering with message-dispatch tests.
+    """
+
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> Never:  # noqa: FBT001
+        raise RuntimeError("set_restoring boom")
+
+    def on_stop_request(self, team_id: uuid.UUID) -> Never:
+        raise RuntimeError("on_stop_request boom")
+
+    def on_stop(self, team_id: uuid.UUID) -> Never:
+        raise RuntimeError("on_stop boom")
+
+    def on_message(self, msg: Message) -> None:
+        pass
+
+
+class _NotifyExposingOrchestrator(Orchestrator):
+    """Orchestrator subclass that exposes ``_notify_subscribers`` to Pykka proxies.
+
+    Pykka's proxy filters out underscore-prefixed methods, so tests that need
+    to drive ``_notify_subscribers`` directly (lifecycle dispatch in
+    Story 17.1 — there is no in-source caller for ``set_restoring``) cannot
+    invoke it through ``system.proxy_ask(...)``. This thin wrapper exposes
+    the helper under a public name without changing production semantics.
+    """
+
+    def notify_subscribers(
+        self,
+        event_method: str,
+        message: Message | None = None,
+        *,
+        team_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Public façade over ``_notify_subscribers`` for proxy-driven tests."""
+        self._notify_subscribers(
+            event_method, message, team_id=team_id, **kwargs
+        )
+
+
+class TestNotifySubscribersTeamIdPropagation:
+    """Story 17.1 — `_notify_subscribers` propagates team_id to lifecycle hooks."""
+
+    def test_set_restoring_passes_team_id_to_subscribers(self) -> None:
+        """AC #2: lifecycle dispatch forwards team_id + restoring=True."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("set_restoring", team_id=orch_team_id, restoring=True)
+
+        assert sub.restoring_calls == [(orch_team_id, True)]
+        assert sub.restoring is True
+
+        system.shutdown()
+
+    def test_on_stop_request_passes_team_id_to_subscribers(self) -> None:
+        """AC #3: `_notify_subscribers("on_stop_request", team_id=...)` forwards team_id."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("on_stop_request", team_id=orch_team_id)
+
+        assert sub.stop_request_team_ids == [orch_team_id]
+
+        system.shutdown()
+
+    def test_on_stop_passes_team_id_to_subscribers(self) -> None:
+        """AC #1: `_notify_subscribers("on_stop", team_id=...)` forwards team_id.
+
+        Exercises the call directly via `_notify_subscribers` (not the full
+        Pykka stop() path) so the test isolates the signature change in 17.1
+        from the body-reordering 17.2 will deliver.
+        """
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("on_stop", team_id=orch_team_id)
+
+        assert sub.stop_team_ids == [orch_team_id]
+        assert sub.stopped is True
+
+        system.shutdown()
+
+    def test_timeout_handler_passes_orchestrator_team_id(self) -> None:
+        """AC #3: `_timeout_handler` call site supplies the orchestrator's own team_id."""
+        config = BaseConfig(name="test-orchestrator", role="Orchestrator")
+        team_id = uuid.uuid4()
+        orch_ref = Orchestrator.start(config=config, team_id=team_id)
+        orch_proxy = orch_ref.proxy()
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub).get()
+
+        # Fire the handler directly (same callback threading.Timer uses)
+        timer = orch_proxy.get_timer().get()
+        timer.timeout_callback()
+
+        assert sub.stop_request_team_ids == [team_id]
+
+        orch_ref.stop()
+
+
+class TestLifecycleFanOutFaultIsolation:
+    """AC #4: per-subscriber try/except keeps the dispatch loop alive across hooks."""
+
+    def test_set_restoring_fault_isolation(self) -> None:
+        """A middle subscriber raising in set_restoring does not block its neighbours."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        first = RecordingSubscriber()
+        middle = _LifecycleRaisingSubscriber()
+        third = RecordingSubscriber()
+
+        orch_proxy.subscribe(first)
+        orch_proxy.subscribe(middle)
+        orch_proxy.subscribe(third)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("set_restoring", team_id=orch_team_id, restoring=False)
+
+        assert first.restoring_calls == [(orch_team_id, False)]
+        assert third.restoring_calls == [(orch_team_id, False)]
+
+        system.shutdown()
+
+    def test_on_stop_request_fault_isolation(self) -> None:
+        """A middle subscriber raising in on_stop_request does not block its neighbours."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        first = RecordingSubscriber()
+        middle = _LifecycleRaisingSubscriber()
+        third = RecordingSubscriber()
+
+        orch_proxy.subscribe(first)
+        orch_proxy.subscribe(middle)
+        orch_proxy.subscribe(third)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("on_stop_request", team_id=orch_team_id)
+
+        assert first.stop_request_team_ids == [orch_team_id]
+        assert third.stop_request_team_ids == [orch_team_id]
+
+        system.shutdown()
+
+    def test_on_stop_fault_isolation(self) -> None:
+        """A middle subscriber raising in on_stop does not block its neighbours."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            _NotifyExposingOrchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, _NotifyExposingOrchestrator)
+
+        first = RecordingSubscriber()
+        middle = _LifecycleRaisingSubscriber()
+        third = RecordingSubscriber()
+
+        orch_proxy.subscribe(first)
+        orch_proxy.subscribe(middle)
+        orch_proxy.subscribe(third)
+
+        orch_team_id = orch_addr.team_id
+        orch_proxy.notify_subscribers("on_stop", team_id=orch_team_id)
+
+        assert first.stop_team_ids == [orch_team_id]
+        assert third.stop_team_ids == [orch_team_id]
+
+        system.shutdown()
+
+
+class TestOnMessageDispatchUnchanged:
+    """AC #5: `_notify_subscribers("on_message", message)` still dispatches as before."""
+
+    def test_on_message_does_not_receive_team_id(self) -> None:
+        """Message dispatch passes the snapshotted message and NO team_id kwarg."""
+        system = ActorSystem()
+        orch_addr = system.createActor(
+            Orchestrator,
+            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        )
+        orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+        sub = RecordingSubscriber()
+        orch_proxy.subscribe(sub)
+
+        msg = UserMessage(content="hello")
+        orch_proxy.restore_message(msg)
+
+        assert len(sub.messages) == 1
+        # team_id-bearing lifecycle counters remain untouched by on_message dispatch
+        assert sub.stop_team_ids == []
+        assert sub.stop_request_team_ids == []
+        assert sub.restoring_calls == []
 
         system.shutdown()

--- a/tests/core/test_orchestrator_timer.py
+++ b/tests/core/test_orchestrator_timer.py
@@ -470,14 +470,14 @@ class _RecordingStopSubscriber:
         self.stop_count: int = 0
         self.messages: list[object] = []
 
-    def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
         """Protocol compliance — no-op for these tests."""
         pass
 
-    def on_stop_request(self) -> None:
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
         self.stop_request_count += 1
 
-    def on_stop(self) -> None:
+    def on_stop(self, team_id: uuid.UUID) -> None:
         self.stop_count += 1
 
     def on_message(self, msg: object) -> None:
@@ -505,7 +505,7 @@ class TestEventSubscriberProtocol:
 
         sub = _MinimalSubscriber()
         # Calling the default method must not raise and must return None
-        assert sub.on_stop_request() is None  # type: ignore[func-returns-value]
+        assert sub.on_stop_request(uuid.uuid4()) is None  # type: ignore[func-returns-value]
 
 
 class TestOrchestratorTimeoutHandler:

--- a/tests/core/test_orchestrator_timer.py
+++ b/tests/core/test_orchestrator_timer.py
@@ -528,7 +528,7 @@ class TestOrchestratorTimeoutHandler:
 
         # Give the actor thread a moment to process any internal messages
         # (snapshot_for_subscribers runs on the caller; subscriber calls are
-        # synchronous within _notify_subscribers, so assertions are immediate).
+        # synchronous within _notify_subscribers_lifecycle, so assertions are immediate).
         assert sub.stop_request_count == 1
         # on_stop is a separate lifecycle hook; the timeout must not trigger it
         assert sub.stop_count == 0

--- a/tests/core/test_pykka_mailbox_drain_on_self_stop.py
+++ b/tests/core/test_pykka_mailbox_drain_on_self_stop.py
@@ -1,0 +1,167 @@
+"""Verify Pykka's mailbox-drain guarantee on the self-stop path.
+
+This test locks down a load-bearing assumption that the cross-package master
+ADR-024 chain relies on: when a Pykka actor calls ``self.stop()`` from inside
+one of its own ``receiveMsg_*`` handlers (the canonical graceful-stop shape
+every ``orchestrator_proxy.stop()`` triggers), Pykka guarantees that every
+queued message in the actor's mailbox is processed BEFORE ``on_stop`` fires.
+
+If a future Pykka upgrade regresses this invariant, this test fails loudly so
+the regression is caught before it silently breaks downstream subscribers
+(``RedisStreamSubscriber.on_stop`` and the rest of the master ADR-024 chain)
+in production — where an ``on_message`` → ``XADD`` could land *after*
+``on_stop`` → ``DEL`` and resurface the very race ADR-024 eliminates.
+
+The verification uses a minimal ``pykka.ThreadingActor`` probe, NOT
+``Orchestrator`` or ``Akgent``: the test is about the Pykka invariant itself,
+not about ``akgentic-core`` semantics.
+
+Cross-references:
+    - ``Orchestrator`` class docstring ("Load-bearing assumption" section) in
+      ``packages/akgentic-core/src/akgentic/core/orchestrator.py``
+    - Master cross-package ADR-024 (akgentic-infra) and package-local ADR-011
+      (akgentic-core).
+    - ``Akgent.receiveMsg_StopRecursively`` — the canonical self-stop shape
+      mirrored here (``self.stop()`` from inside a ``receiveMsg_*`` handler).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Generator
+from typing import Any
+
+import pykka
+import pytest
+
+# Number of follow-up messages the trigger handler enqueues to itself before
+# calling self.stop(). The expected total is N_FOLLOW_UPS + 1 message entries
+# (the initial "trigger" plus N follow-ups), then exactly one ("on_stop",).
+N_FOLLOW_UPS = 5
+
+
+@pytest.fixture(autouse=True)
+def cleanup_actors() -> Generator[None, None, None]:
+    """Stop any leaked probe actors after each test so failures don't cascade."""
+    yield
+    pykka.ActorRegistry.stop_all()
+
+
+class _MailboxDrainProbe(pykka.ThreadingActor):
+    """Minimal Pykka actor that records each receive and the on_stop call.
+
+    On receiving the ``"trigger"`` message, the handler enqueues
+    ``N_FOLLOW_UPS`` additional messages to itself via ``self.actor_ref.tell``
+    and then calls ``self.stop()`` from inside the same handler. This mirrors
+    ``Akgent.receiveMsg_StopRecursively`` → ``self.stop()`` — the canonical
+    graceful-stop shape every ``orchestrator_proxy.stop()`` triggers.
+    """
+
+    def __init__(self, recorder: list[tuple[str, Any]], lock: threading.Lock) -> None:
+        super().__init__()
+        self.recorder = recorder
+        self.lock = lock
+
+    def on_receive(self, message: Any) -> None:
+        with self.lock:
+            self.recorder.append(("msg", message))
+        if message == "trigger":
+            # Enqueue follow-ups FIRST, then request self-stop. Pykka must
+            # process the follow-ups before on_stop fires.
+            for i in range(N_FOLLOW_UPS):
+                self.actor_ref.tell(f"follow-up-{i}")
+            self.stop()
+
+    def on_stop(self) -> None:
+        with self.lock:
+            self.recorder.append(("on_stop",))
+
+
+def test_pykka_drains_mailbox_before_on_stop_on_self_stop() -> None:
+    """Pykka must drain the mailbox before ``on_stop`` fires on self-stop.
+
+    The trigger handler enqueues ``N_FOLLOW_UPS`` follow-up messages and then
+    calls ``self.stop()`` from inside the same handler. After the actor has
+    fully stopped, the recorder must contain:
+
+    - exactly ``N_FOLLOW_UPS + 1`` ``("msg", ...)`` entries (trigger + follow-ups),
+    - exactly one ``("on_stop",)`` entry sitting AFTER every ``("msg", ...)``
+      entry (index == ``N_FOLLOW_UPS + 1``),
+    - no ``("msg", ...)`` entry after the ``("on_stop",)`` entry.
+
+    If any assertion fails, Pykka's mailbox-drain invariant has regressed on
+    the self-stop path, and the cross-package master ADR-024 chain
+    (RedisStreamSubscriber, etc.) can no longer rely on it.
+    """
+    recorder: list[tuple[str, Any]] = []
+    lock = threading.Lock()
+    actor_ref = _MailboxDrainProbe.start(recorder, lock)
+    try:
+        # Send ONLY the trigger from the test thread. The handler itself
+        # enqueues follow-ups and then calls ``self.stop()`` — that internal
+        # ``self.stop()`` is what places ``_ActorStop`` in the mailbox AFTER
+        # the follow-ups, exercising the invariant under test.
+        #
+        # We must NOT call ``actor_ref.stop()`` from the test here: that would
+        # enqueue a second ``_ActorStop`` racing with ``tell("trigger")`` and
+        # could land in the mailbox BEFORE the follow-ups, short-circuiting
+        # the drain we are trying to verify.
+        actor_ref.tell("trigger")
+
+        # Wait for the actor to terminate of its own accord via the self-stop
+        # path. ``actor_stopped`` is the same threading.Event the actor loop
+        # sets in ``_stop`` — so this returns exactly when ``on_stop`` has
+        # finished (and the on_stop entry is in the recorder).
+        stopped = actor_ref.actor_stopped.wait(timeout=5)
+        assert stopped, (
+            "Self-stop path did not terminate within 5s — Pykka behaviour has "
+            "changed unexpectedly. See ADR-024 chain."
+        )
+    finally:
+        # Defensive: stop any remaining actors in case the assertions below
+        # short-circuit before the autouse fixture runs.
+        pykka.ActorRegistry.stop_all()
+
+    # Snapshot the recorder under the lock so any in-flight handler thread
+    # cannot mutate it mid-read (the actor is stopped at this point, but
+    # honour the lock contract).
+    with lock:
+        snapshot = list(recorder)
+
+    msg_entries = [e for e in snapshot if e[0] == "msg"]
+    expected_msg_count = N_FOLLOW_UPS + 1
+    assert len(msg_entries) == expected_msg_count, (
+        f"Pykka mailbox-drain invariant violated — expected {expected_msg_count} "
+        f"message handlers to run before on_stop, observed {len(msg_entries)}. "
+        "See ADR-024 chain: RedisStreamSubscriber.on_stop and downstream "
+        f"subscribers depend on this guarantee. Recorder: {snapshot!r}"
+    )
+
+    on_stop_entries = [e for e in snapshot if e[0] == "on_stop"]
+    assert len(on_stop_entries) == 1, (
+        f"on_stop fired {len(on_stop_entries)} times — expected exactly one. Recorder: {snapshot!r}"
+    )
+
+    on_stop_idx = snapshot.index(("on_stop",))
+    assert on_stop_idx == expected_msg_count, (
+        f"on_stop fired before mailbox drained — on_stop index is {on_stop_idx}, "
+        f"expected {expected_msg_count}. ADR-024 chain depends on this ordering. "
+        f"Recorder: {snapshot!r}"
+    )
+
+    # Belt-and-braces: nothing after on_stop.
+    after_on_stop = snapshot[on_stop_idx + 1 :]
+    assert after_on_stop == [], (
+        f"Unexpected entries observed AFTER on_stop: {after_on_stop!r}. "
+        "ADR-024 chain assumes on_stop is the terminal event. "
+        f"Full recorder: {snapshot!r}"
+    )
+    # Confirm the prefix is the expected message sequence (trigger first, then
+    # follow-ups in enqueue order — Pykka preserves FIFO per producer).
+    assert snapshot[0] == ("msg", "trigger"), (
+        f"First handled message should be 'trigger', got {snapshot[0]!r}"
+    )
+    for i in range(N_FOLLOW_UPS):
+        assert snapshot[i + 1] == ("msg", f"follow-up-{i}"), (
+            f"Follow-up ordering violated at index {i + 1}: {snapshot[i + 1]!r}"
+        )

--- a/tests/test_epic3_integration.py
+++ b/tests/test_epic3_integration.py
@@ -110,13 +110,13 @@ class TestOrchestratorTimerIntegration:
             def __init__(self) -> None:
                 self.stop_request_count = 0
 
-            def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+            def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
                 pass
 
-            def on_stop_request(self) -> None:
+            def on_stop_request(self, team_id: uuid.UUID) -> None:
                 self.stop_request_count += 1
 
-            def on_stop(self) -> None:
+            def on_stop(self, team_id: uuid.UUID) -> None:
                 pass
 
             def on_message(self, msg: Message) -> None:

--- a/tests/test_timer_integration.py
+++ b/tests/test_timer_integration.py
@@ -110,13 +110,13 @@ class TestOrchestratorTimerIntegration:
             def __init__(self) -> None:
                 self.stop_request_count = 0
 
-            def set_restoring(self, restoring: bool) -> None:  # noqa: FBT001
+            def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
                 pass
 
-            def on_stop_request(self) -> None:
+            def on_stop_request(self, team_id: uuid.UUID) -> None:
                 self.stop_request_count += 1
 
-            def on_stop(self) -> None:
+            def on_stop(self, team_id: uuid.UUID) -> None:
                 pass
 
             def on_message(self, msg: Message) -> None:


### PR DESCRIPTION
# Epic 17 — EventSubscriber `team_id`-Aware Lifecycle Hooks & Unsubscribe Reversal

This is the umbrella PR for **Epic 17** (`akgentic-core` slice of master ADR
`akgentic-infra/adr-024`, package-local
[`akgentic-core/adr-011`](../decisions/adr-011-eventsubscriber-team-id-lifecycle.md)).
It widens the `EventSubscriber` Protocol so lifecycle hooks carry the
orchestrator's `team_id`, reverses the unsubscribe ordering in
`Orchestrator.on_stop`, and documents the Pykka mailbox-drain assumption that
makes the rest of the design correct.

The slice ships as three stacked commits on a single branch, merged together
into `master`. Downstream signature updates in `akgentic-team`,
`akgentic-infra`, `akgentic-infra-department`, and `akgentic-infra-enterprise`
ship as separate stories per Golden Rule #4, gated on a new `akgentic-core`
wheel being published from this PR's merge.

## Stories

- [x] `17-1-widen-eventsubscriber-protocol-and-notify-subscribers` (Relates to #71)
- [x] `17-2-reverse-unsubscribe-ordering-in-orchestrator-on-stop` — fan-out before clear in `Orchestrator.on_stop` (Relates to #73)
- [x] `17-3-verify-pykka-mailbox-drain-on-self-stop` — verification test + load-bearing-assumption docstring (Relates to #74)

## Review status

### 17.1 — Widen `EventSubscriber` Protocol + propagate `team_id`

**Verdict: APPROVED with one required change, now fixed in this PR.**

Rex (code review) flagged Amelia's `_notify_subscribers` helper as fragile:
the dispatch loop branched implicitly on "which arg is None" (`team_id` vs
`message` vs no-arg). The `else: method()` branch was dead code — after this
epic every Protocol hook is either message-bearing (`on_message`) or
lifecycle (`set_restoring` / `on_stop_request` / `on_stop`, all of which
carry `team_id`).

**Fix applied (single fix-commit):** split the unified helper into two
explicit helpers, each with a single call shape and a single responsibility:

- `_notify_subscribers_message(event_method, message)` — snapshots actor
  addresses on the caller thread, then fans out `on_message(snapshot)` to
  every subscriber.
- `_notify_subscribers_lifecycle(event_method, team_id, **kwargs)` — every
  lifecycle hook carries `team_id` as its first positional argument; extra
  kwargs (e.g. `restoring=True` for `set_restoring`) are forwarded.

Both helpers preserve the per-subscriber `try / except Exception` guard
and its ERROR-level log line verbatim — the fault-isolation contract
(one subscriber fails → others still run) is non-negotiable (AC #4).

All call sites in `orchestrator.py` and the `_NotifyExposingOrchestrator`
test wrapper were updated accordingly. The wrapper now exposes
`notify_subscribers_lifecycle` and `notify_subscribers_message` as public
façades for proxy-driven tests, since Pykka proxies filter underscore-prefixed
methods.

Quality gates (verified locally on the fix-commit):

- `ruff check packages/akgentic-core/src/`: All checks passed
- `mypy packages/akgentic-core/src/`: Success — no issues found in 17 source files
- `pytest packages/akgentic-core/tests/`: **480 passed**
- Branch coverage on `orchestrator.py`: **91 %** (≥ 80 % threshold, from
  the story's measurement; the split helpers add no new branches relative
  to the unified version Amelia shipped)

### 17.2 — Reverse unsubscribe ordering in `Orchestrator.on_stop`

Pending — will land as a stacked commit on top of 17.1, in its own review pass.

### 17.3 — Verify Pykka mailbox-drain on self-stop

PASS — see slice-complete summary below.

## Scope guard

All changes in this PR stay inside `packages/akgentic-core/` — no edits,
branches, or PRs in any other submodule (Golden Rule #4). Downstream
subscriber updates in `akgentic-team`, `akgentic-infra`,
`akgentic-infra-department`, and `akgentic-infra-enterprise` are handled by
their own submodule stories after a new `akgentic-core` wheel is published.

Relates to #71

- 17-2 review: PASS — single-line behavioural change (`self.subscribers.clear()` after `super().on_stop()`) plus 3 focused behavioural tests covering ACs #1-#5 end-to-end via `system.shutdown()`. All quality gates green (mypy strict clean, ruff clean on touched files, 483/483 tests pass, coverage 90.01%). One minor non-blocking finding: commit message includes "Implements ADR-011 §3" which technically violates Golden Rule #8's "no ADR-NNN in commit messages" — unfixable without history rewrite, flagged for visibility. Pre-existing 5 `test_agent_state.py` failures under `--cov=akgentic.core.orchestrator` scope confirmed pre-existing on parent commit 4cfb742; unrelated to 17.2.
- 17-3 review: PASS — focused verification test using a minimal `pykka.ThreadingActor` probe that exercises the genuine self-stop path (`self.stop()` from inside `on_receive`, mirroring `Akgent.receiveMsg_StopRecursively`). Deterministic synchronization via `actor_ref.actor_stopped.wait(timeout=5)` — no sleep-based races. Docstring on `Orchestrator` references the correct post-17.1/17.2 dispatch shape `self._notify_subscribers_lifecycle("on_stop", self.team_id)` and the four required points (invariant, test pointer, downstream consumers, protected call shape). ADR-NNN references confined to docstrings and assertion error messages (Golden Rule #8 ALLOWED-list); no behavioural assertions on ADR strings, no ADR-NNN in commit message. All quality gates green: 484 tests pass, mypy strict clean, ruff clean, branch coverage on `orchestrator.py` at 91% (matches 17.2 baseline). All changes confined to `packages/akgentic-core/` (Golden Rule #4 OK). No fixup commit required.

## Epic 17 slice complete

All three stories of the `akgentic-core` slice of master ADR-024 / package-local
ADR-011 are now `done` locally:

| Story | Issue | Commit | Review |
|---|---|---|---|
| 17.1 — Widen `EventSubscriber` Protocol + propagate `team_id` | #71 | `4cfb742` (post-review fixup) | PASS w/ required fix applied |
| 17.2 — Reverse unsubscribe ordering in `Orchestrator.on_stop` | #73 | `0530f4d` | PASS |
| 17.3 — Verify Pykka mailbox-drain on self-stop + load-bearing-assumption docstring | #74 | `f48ad9a` | PASS |

**Pykka invariant verified:** under Pykka 4.4.2, when an actor calls
`self.stop()` from inside its own `receiveMsg_*` handler, every queued
message is processed before `on_stop` fires. ADR-011 §4's verification gate is
satisfied; no course-correction triggered. The master ADR-024 cross-package
chain can rely on the guarantee.

**Cross-package downstream consumers gated on this PR's merge** (each ships
as a separate story/branch/PR per Golden Rule #4, against a new
`akgentic-core` wheel published from this merge):

- `akgentic-team` ADR-18 — remove `TeamManager._teardown_team`'s
  unsubscribe-before-stop loop now that `Orchestrator.on_stop` fans out itself.
- `akgentic-infra` epic-27 — update `RedisStreamSubscriber.on_stop` to consume
  `team_id` from the lifecycle hook and rely on the mailbox-drain invariant
  for safe `XADD` / `DEL` ordering.
- `akgentic-infra-department` ADR-002 — wire the widened Protocol through the
  department-tier subscriber roster.
- `akgentic-infra-enterprise` ADR-030 — wire the widened Protocol through the
  enterprise-tier subscriber roster.

Final quality gates (post-17.3, full submodule suite):

- `pytest packages/akgentic-core/tests/`: **484 passed**
- `mypy packages/akgentic-core/src/`: Success — no issues found in 17 source files
- `ruff check packages/akgentic-core/src/`: All checks passed
- Branch coverage on `orchestrator.py`: **91 %** (≥ 80 % gate, matches 17.2 baseline)
