### PR TITLE
feat(akgentic-core): epic 18 — Non-Blocking Orchestrator Stop (18-1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-core"
-version = "1.3.0"
+version = "1.3.1"
 description = "Actor framework for building agent-based systems"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.4.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
 ]
@@ -32,6 +33,12 @@ packages = ["src/akgentic"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+# --timeout is a deadlock backstop, not a latency budget. The actor stop/teardown
+# paths can wedge on a regression (a blocking ask on the actor thread waits forever);
+# a finite per-test bound turns a true hang into a fast failure instead of a frozen
+# suite. core is a pure-unit, no-LLM suite so the bound is generous purely as headroom.
+# --timeout-method=thread dumps every thread's stack when it fires, pinpointing the wedge.
+addopts = "--timeout=300 --timeout-method=thread"
 
 [tool.coverage.run]
 source = ["src/akgentic"]

--- a/src/akgentic/core/actor_address_impl.py
+++ b/src/akgentic/core/actor_address_impl.py
@@ -47,10 +47,28 @@ class ActorAddressImpl(ActorAddress):
     def __init__(self, actor_ref: ActorRef[Any]) -> None:
         """Initialize with a Pykka ActorRef.
 
+        Caches the address *identity* (``agent_id`` and ``role``) eagerly at
+        construction (ADR-012 §5). Addresses are only ever built from live refs,
+        so the underlying actor is alive here; caching makes ``agent_id``,
+        ``role``, ``__eq__`` and ``__hash__`` survive the actor's garbage
+        collection — required so ``get_team()`` and the telemetry identity guards
+        stay safe during teardown over already-collected senders.
+
         Args:
             actor_ref: The Pykka ActorRef to wrap.
         """
         self._actor_ref = actor_ref
+        self._agent_id: uuid.UUID | None = None
+        self._role: str | None = None
+        try:
+            actor = actor_ref._actor_weakref()
+            if actor is not None:
+                self._agent_id = actor.agent_id
+                self._role = actor.config.role
+        except Exception:  # noqa: BLE001
+            # Identity stays unset → properties fall back to live resolve.
+            self._agent_id = None
+            self._role = None
 
     def _resolve_actor(self) -> Any:
         """Dereference the weak reference to the underlying actor.
@@ -68,11 +86,16 @@ class ActorAddressImpl(ActorAddress):
 
     @property
     def agent_id(self) -> uuid.UUID:
-        """Unique identifier from the underlying actor.
+        """Unique identifier (cached at construction; GC-safe — ADR-012 §5).
+
+        Returns the cached identity if available, falling back to a live resolve
+        only when the cache is unset.
 
         Returns:
             UUID from the actor's agent_id attribute.
         """
+        if self._agent_id is not None:
+            return self._agent_id
         return self._resolve_actor().agent_id  # type: ignore[no-any-return]
 
     @property
@@ -87,11 +110,17 @@ class ActorAddressImpl(ActorAddress):
 
     @property
     def role(self) -> str:
-        """Agent role from the underlying actor's config.
+        """Agent role (cached at construction; GC-safe — ADR-012 §5).
+
+        Returns the cached identity if available, falling back to a live resolve
+        only when the cache is unset. Role is fixed after construction for all
+        current agents, so caching it is safe.
 
         Returns:
             Role string from config, or class name as fallback.
         """
+        if self._role is not None:
+            return self._role
         actor = self._resolve_actor()
         return actor.config.role  # type: ignore[no-any-return]
 

--- a/src/akgentic/core/actor_system_impl.py
+++ b/src/akgentic/core/actor_system_impl.py
@@ -23,6 +23,7 @@ from akgentic.core.actor_address_impl import ActorAddressImpl
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.message import Message
+from akgentic.core.orchestrator import STOP_TIMEOUT
 from akgentic.core.utils.deserializer import import_class
 
 # Logger for agent operations
@@ -239,30 +240,44 @@ class ActorSystem(ExecutionContext):
 
         This method:
         1. Stops the execution context listener
-        2. Stops all orchestrators in parallel
-        3. Cleans up any remaining actors
+        2. Initiates a non-blocking stop on every orchestrator (the ``timeout``
+           becomes each orchestrator's grace period), then waits on each
+           orchestrator's completion event (ADR-012 §6/shutdown).
+        3. Cleans up any remaining actors as a last-resort force-kill
+
+        Because the per-orchestrator backstops run concurrently, total shutdown
+        stays bounded by ~``timeout`` even if a child wedges — and the former
+        deadlock no longer degrades to a 120 s stall.
 
         Args:
             timeout: Maximum time in seconds to wait for shutdown. Defaults to 120.
         """
         super().shutdown(timeout=timeout)
 
-        # Start all stops in parallel (non-blocking)
-        stop_futures = [actor.proxy().stop() for actor in self.orchestrators]
-
-        # Wait for all stops to complete
-        for future in stop_futures:
+        # Issue the non-blocking stop on every orchestrator FIRST (so the
+        # backstops run concurrently), collecting each completion event.
+        grace = float(timeout) if timeout is not None else STOP_TIMEOUT
+        stop_events: list[Any] = []
+        for actor in self.orchestrators:
             try:
-                future.get(timeout=timeout)
+                stop_events.append(actor.proxy().stop(grace).get(timeout=timeout))
             except pykka.Timeout:
-                logger.warning("Warning: Timeout while stopping an actor.")
-            except Exception as e:
-                logger.error(f"Error: Failed to stop actor: {e}")
+                logger.warning("Warning: Timeout while initiating an orchestrator stop.")
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"Error: Failed to initiate orchestrator stop: {e}")
+
+        # Then wait on each event with NO timeout — the backstop guarantees each
+        # is set within ~grace, so this cannot hang.
+        for event in stop_events:
+            try:
+                event.wait()
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"Error: Failed to wait on orchestrator stop event: {e}")
 
         # Pykka's proxy().stop() future resolves when the stop() method returns,
-        # NOT when the actor is fully deregistered. Internally, stop() sends 
+        # NOT when the actor is fully deregistered. Internally, stop() sends
         # (fire-and-forget) a _ActorStop() messages to the actor's own mailbox.
-        # The actor thread must still process that message, run on_stop(), and 
+        # The actor thread must still process that message, run on_stop(), and
         # deregister from ActorRegistry. Without this pause, get_all() below may see
         # actors that have accepted the stop request but haven't finished processing it yet.
         sleep(0.2)

--- a/src/akgentic/core/agent.py
+++ b/src/akgentic/core/agent.py
@@ -232,6 +232,9 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
 
         self._current_message: Message | None = None
         self._children: list[ActorAddress] = []
+        # Teardown guard (ADR-012). Base agents never flip this; the Orchestrator
+        # overrides stop() to set it while draining the team non-blocking.
+        self._stopping: bool = False
 
         ## Initialize from explicit parameters
         self.agent_id: uuid.UUID = agent_id or uuid.uuid4()
@@ -509,29 +512,43 @@ class Akgent(pykka.ThreadingActor, Generic[ConfigType, StateType]):  # noqa: UP0
         """
         self.stop()
 
+    def stop_children(self, blocking: bool = True) -> None:
+        """Stop every child actor (ADR-012 §1).
+
+        Blocking mode waits for each child's subtree to tear down (the legacy
+        behaviour) via a blocking ``proxy_ask(child).stop()`` and removes the
+        child from ``_children`` as it goes. Non-blocking mode fire-and-forgets a
+        ``proxy_tell(child).stop()`` per child and relies on the caller to
+        observe completion another way (the orchestrator keys off the
+        ``StopMessage`` telemetry stream); ``_children`` hygiene then happens via
+        the ``ChildStopped`` cleanup path.
+
+        Args:
+            blocking: If True (default), block on each child's stop and remove it
+                from ``_children``. If False, tell each live child to stop without
+                waiting.
+        """
+        for child in self._children.copy():
+            if not child.is_alive():
+                self._children.remove(child)
+                continue
+            if blocking:
+                self.proxy_ask(child, Akgent).stop()
+                self._children.remove(child)
+            else:
+                self.proxy_tell(child, Akgent).stop()
+
     def stop(self) -> None:
         """Stop this agent and all children recursively.
 
-        Iterates children list and stops each child before stopping self.
+        Stops each child (blocking) before stopping self, preserving the
+        "team is stopped before the next instruction" guarantee for
+        non-orchestrator agents. The Orchestrator overrides this with a
+        non-blocking variant (ADR-012 §2).
         """
         logger.info(f"### [{self.config.name}] Stopping recursively ...")
-        for child in self._children.copy():
-            self._stop_child(child)
+        self.stop_children(blocking=True)
         super().stop()
-
-    def _stop_child(self, child: ActorAddress) -> None:
-        """Stop a single child actor.
-
-        Args:
-            child: Child actor address to stop.
-        """
-        if child.is_alive():
-            self.proxy_ask(child, Akgent).stop()
-
-        try:
-            self._children.remove(child)
-        except Exception:
-            logger.error(f"ERROR: stop_child: Actor with reference {child} doesn't exist")
 
     def on_stop(self) -> None:
         """Cleanup hook called when actor stops.

--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -36,6 +36,12 @@ logger = logging.getLogger(__name__)
 
 TIMER_DELAY = 3600  # 1 hour default inactivity timeout
 
+# Default grace period (seconds) for a non-blocking orchestrator stop before the
+# backstop timer forces teardown (ADR-012 §2/§4). It is the single stop timeout:
+# callers wait on the returned event with NO timeout, and the backstop guarantees
+# the event is set within ~STOP_TIMEOUT seconds.
+STOP_TIMEOUT = 30.0
+
 
 class Timer:
     """Helper class for inactivity timeout management.
@@ -252,6 +258,12 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         # Shutdown flag
         self._stopping: bool = False
 
+        # Non-blocking-stop completion signal + backstop timer (ADR-012 §2/§4).
+        # Created lazily when stop() is first called; the backstop forces
+        # finalization if a child wedges and the roster never empties.
+        self._stop_event: threading.Event | None = None
+        self._stop_backstop: threading.Timer | None = None
+
         # Event subscribers for Phase 3 extensibility
         self.subscribers: list[EventSubscriber] = []
 
@@ -267,9 +279,15 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
 
     @override
     def on_stop(self) -> None:
+        self._cancel_stop_backstop()
         self._notify_subscribers_lifecycle("on_stop", self.team_id)
         super().on_stop()
         self.subscribers.clear()
+        # Release any caller blocked in stop().wait(). Event.set() is idempotent,
+        # so the graceful path and the forced (backstop) path can both call it
+        # with no guard flag (ADR-012 §4).
+        if self._stop_event is not None:
+            self._stop_event.set()
         logger.info(f">>> [{self.config.name}] Stopped !")
 
     @override
@@ -391,20 +409,29 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_StopMessage(self, message: StopMessage, sender: ActorAddress) -> None:
-        """Handle agent stop events.
+        """Handle agent stop events (ADR-012 §3).
 
-        Skips recording if orchestrator is shutting down (_stopping flag).
+        Always records the ``StopMessage`` and invalidates the team-roster cache
+        so ``get_team()`` reflects each child stopping. During an in-progress
+        non-blocking teardown (``_stopping``) this doubles as the completion
+        signal: once the roster empties, the orchestrator finalizes via
+        ``_finalize_stop()`` (event is set in ``on_stop``). Subscriber dispatch is
+        suppressed while ``_stopping`` to preserve the XADD-before-DEL ordering
+        and resume-history semantics (teardown ``StopMessage``s must stay out of
+        the stream).
 
         Args:
             message: StopMessage from agent
             sender: ActorAddress of sending agent
         """
-        if self._stopping:
-            # Don't record StopMessages during orchestrator shutdown
-            return
-
         self.messages.append(message)
-        self._current_team_members = None  # Clear cache
+        self._current_team_members = None  # Invalidate roster cache
+
+        if self._stopping:
+            if not self.get_team():  # whole tree down (GC-safe identity — ADR-012 §5)
+                self._finalize_stop()
+            return  # suppress subscriber dispatch during teardown
+
         self._notify_subscribers_message("on_message", message)
 
     def receiveMsg_SentMessage(self, message: SentMessage, sender: ActorAddress) -> None:
@@ -539,13 +566,17 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         if self._current_team_members is not None:
             return self._current_team_members
 
-        # Compute from message history using comprehensions
+        # Compute from message history using comprehensions.
+        # Exclude the orchestrator ITSELF by identity (agent_id), not by role
+        # string: the orchestrator is never its own team member, and a
+        # role-string filter both misses a self that carries a non-orchestrator
+        # role and wrongly drops legitimate sub-orchestrator members.
         started_agentid_addr_dict = {
             str(msg.sender.agent_id): msg.sender
             for msg in self.messages
             if isinstance(msg, StartMessage)
             and msg.sender is not None
-            and msg.sender.role != "Orchestrator"
+            and msg.sender.agent_id != self.agent_id
         }
         stopped_agent_id_set = {
             str(msg.sender.agent_id)
@@ -637,16 +668,99 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         """
         return self.state_dict
 
-    def stop(self) -> None:
-        """Override stop to cancel timer and set _stopping flag before shutdown.
+    def stop(self, grace_timeout: float = STOP_TIMEOUT) -> threading.Event:  # type: ignore[override]
+        """Initiate a non-blocking, recursive team teardown (ADR-012 §2).
 
-        Cancels the inactivity timer first to prevent it from firing during
-        shutdown, then sets the _stopping flag to suppress StopMessage recording,
-        then calls the parent stop() method.
+        Tells every child to stop, then returns IMMEDIATELY without waiting — the
+        orchestrator's actor thread stays free to answer reentrant asks
+        (``get_team()``) while the team drains bottom-up. This is precisely what
+        makes stop deadlock-proof: the orchestrator never blocks on a child, so a
+        child that re-enters the orchestrator mid-message can always be served.
+
+        The returned :class:`threading.Event` is the completion signal. It is
+        **guaranteed** to be set within ~``grace_timeout`` seconds, one of two
+        ways:
+
+        * **gracefully** — the moment the last agent has stopped (the common
+          case, typically milliseconds); or
+        * **forcibly** — if a child wedges and the team never reaches quiescence,
+          the internal backstop timer fires at ``grace_timeout`` and tears the
+          orchestrator down anyway (logs a WARNING; the wedged child is reaped
+          later by ``ActorRegistry.stop_all()``).
+
+        To block until the team is fully stopped, wait on the event with **no
+        timeout** — it cannot hang, because the backstop bounds it::
+
+            orchestrator.stop(grace_timeout).wait()    # returns within ~grace
+
+        Calling ``stop()`` and ignoring the event is a valid fire-and-forget
+        teardown. Idempotent: calling ``stop()`` again while already stopping
+        returns the same event and does not re-tell the children.
+
+        Args:
+            grace_timeout: Seconds to allow for graceful quiescence before the
+                backstop forces teardown. This is the ONLY stop timeout. Callers
+                do NOT pass a separate wait timeout: a wait shorter than this
+                could only ever yield a spurious failure, and a longer one is
+                redundant (the event is already guaranteed to set by
+                ``grace_timeout``).
+
+        Returns:
+            A ``threading.Event`` set once the orchestrator is fully stopped —
+            mailbox drained, subscribers' ``on_stop`` fired, actor deregistered.
         """
-        self._timer.cancel()
+        if self._stopping:
+            # Idempotent — same event, no re-tell of children.
+            assert self._stop_event is not None
+            return self._stop_event
+
+        self._timer.cancel()  # no inactivity auto-stop mid-teardown
         self._stopping = True
-        super().stop()
+        self._stop_event = threading.Event()
+        self.stop_children(blocking=False)  # TELL children; do not block
+        self._arm_stop_backstop(grace_timeout)  # guarantees the event sets (§4)
+        if not self.get_team():  # zero-agent team: nothing will report
+            self._finalize_stop()
+        return self._stop_event
+
+    def _arm_stop_backstop(self, grace_timeout: float) -> None:
+        """Arm the backstop timer that forces teardown after ``grace_timeout``."""
+        self._stop_backstop = threading.Timer(grace_timeout, self._force_stop)
+        self._stop_backstop.daemon = True
+        self._stop_backstop.start()
+
+    def _cancel_stop_backstop(self) -> None:
+        """Cancel the backstop timer if armed (idempotent)."""
+        if self._stop_backstop is not None:
+            self._stop_backstop.cancel()
+            self._stop_backstop = None
+
+    def _finalize_stop(self) -> None:
+        """Stop the orchestrator actor itself WITHOUT re-running stop_children.
+
+        ``super().stop()`` == ``Akgent.stop()`` == blocking ``stop_children``, which
+        hangs on a child that is alive-but-mid-``on_stop``. The native ref stop
+        enqueues ``_ActorStop``; the mailbox drains and ``on_stop`` runs (setting
+        the event). Cancels the backstop so it cannot fire spuriously after a
+        graceful finalize.
+        """
+        self._cancel_stop_backstop()
+        self.actor_ref.stop(block=False)
+
+    def _force_stop(self) -> None:
+        """Force finalization from the backstop Timer thread (ADR-012 §4).
+
+        Runs on the Timer thread, NOT the actor thread. Uses the native
+        ``actor_ref.stop(block=False)`` — NOT ``super().stop()`` — so it does not
+        re-enter ``stop_children`` and block on the very child that wedged. The
+        native stop enqueues ``_ActorStop``; the orchestrator's own actor thread
+        then drains its mailbox and runs ``on_stop`` (which sets the event).
+        """
+        if self.actor_ref.is_alive():
+            logger.warning(
+                "Orchestrator stop timed out (team=%s); forcing teardown", self.team_id
+            )
+            self.actor_ref.stop(block=False)
 
     # =============================================================================
     # Agent Profile Catalog Management

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -14,7 +14,12 @@ from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message, UserMessage
-from akgentic.core.messages.orchestrator import EventMessage, SentMessage, StartMessage
+from akgentic.core.messages.orchestrator import (
+    EventMessage,
+    SentMessage,
+    StartMessage,
+    StopMessage,
+)
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 
 
@@ -790,6 +795,14 @@ class TestSnapshotForSubscribers:
         assert dispatched.sender.role == "TestAgent"
         assert dispatched.sender.team_id == child_addr.team_id
 
+        # Complete the simulated agent lifecycle: a registered member deregisters
+        # when it stops (StopMessage), clearing the orchestrator roster so the
+        # non-blocking stop can finalize. The injected StartMessage above alone
+        # leaves a phantom member that never reports a StopMessage.
+        stop_msg = StopMessage()
+        stop_msg.init(child_addr, child_addr.team_id)
+        orch_proxy.receiveMsg_StopMessage(stop_msg, child_addr)
+
         system.shutdown()
 
     def test_orchestrator_messages_retain_actor_address_impl(self) -> None:
@@ -826,6 +839,11 @@ class TestSnapshotForSubscribers:
         ]
         assert len(agent_starts) == 1
         assert isinstance(agent_starts[0].sender, ActorAddressImpl)
+
+        # Complete the simulated agent lifecycle so the roster clears before stop.
+        stop_msg = StopMessage()
+        stop_msg.init(child_addr, child_addr.team_id)
+        orch_proxy.receiveMsg_StopMessage(stop_msg, child_addr)
 
         system.shutdown()
 
@@ -958,6 +976,11 @@ class TestSnapshotForSubscribers:
         ]
         assert len(internal_starts) == 1
         assert isinstance(internal_starts[0].parent, ActorAddressImpl)
+
+        # Complete the simulated agent lifecycle so the roster clears before stop.
+        stop_msg = StopMessage()
+        stop_msg.init(child_addr, child_addr.team_id)
+        orch_proxy.receiveMsg_StopMessage(stop_msg, child_addr)
 
         system.shutdown()
 

--- a/tests/core/test_orchestrator_stop.py
+++ b/tests/core/test_orchestrator_stop.py
@@ -1,0 +1,376 @@
+"""Behaviour tests for the non-blocking orchestrator stop (ADR-012).
+
+Ports the deterministic reproduction from
+``packages/akgentic-team/research/test_stop_during_processing_deadlock.py`` into
+the CI suite (reusing its ``RecordingSubscriber`` / ``DeadlockWorker`` /
+``TelemetryWorker`` / ``_build_team`` harness) and adds the behaviour matrix from
+the story Testing section.
+
+All assertions are behaviour-only — no ADR-reference-string checks (Golden
+Rule #8). Uses ONLY ``akgentic-core`` primitives (no LLM / infra / TestModel).
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import threading
+import time
+import uuid
+from collections import Counter
+from collections.abc import Generator
+
+import pykka
+import pytest
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressImpl
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.orchestrator import Orchestrator
+
+# Signals the moment a worker is INSIDE its message handler (actor busy).
+_in_handler = threading.Event()
+
+# How long a worker holds its handler open so the stop request arrives while busy.
+_HANDLER_HOLD_S = 0.5
+
+
+@pytest.fixture(autouse=True)
+def cleanup_actors() -> Generator[None, None, None]:
+    """Stop any leaked actors after each test so failures don't cascade."""
+    yield
+    pykka.ActorRegistry.stop_all()
+
+
+class RecordingSubscriber:
+    """Captures the orchestrator's ``on_message`` telemetry fan-out so a test can
+    observe which messages it records and forwards to subscribers."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    def on_message(self, msg: Message) -> None:
+        self.messages.append(msg)
+
+    # Lifecycle hooks — no-ops, present to satisfy the EventSubscriber protocol.
+    def set_restoring(self, team_id: uuid.UUID, restoring: bool) -> None:  # noqa: FBT001
+        ...
+
+    def on_stop_request(self, team_id: uuid.UUID) -> None:
+        ...
+
+    def on_stop(self, team_id: uuid.UUID) -> None:
+        ...
+
+    def type_counts(self) -> Counter[str]:
+        return Counter(m.__class__.__name__ for m in self.messages)
+
+
+class DeadlockWorker(Akgent):
+    """Mid-message, re-enters the orchestrator via ``get_team()`` — the reentrant
+    edge. Mirrors ``BaseAgent._build_structured_output_type()``."""
+
+    def receiveMsg_UserMessage(self, message: UserMessage, sender: ActorAddress) -> None:
+        _in_handler.set()
+        time.sleep(_HANDLER_HOLD_S)
+        # Blocking ask back to the orchestrator. With a non-blocking orchestrator
+        # stop this always resolves; with the legacy blocking stop it deadlocks.
+        self.get_team()
+
+
+class TelemetryWorker(Akgent):
+    """Mid-message, does NOT touch the orchestrator — no deadlock. Emits its final
+    ``ProcessedMessage`` when the handler returns, as it is being stopped."""
+
+    def receiveMsg_UserMessage(self, message: UserMessage, sender: ActorAddress) -> None:
+        _in_handler.set()
+        time.sleep(_HANDLER_HOLD_S)
+
+
+class WedgedWorker(Akgent):
+    """Never stops gracefully — overrides ``stop()`` to ignore the request so the
+    orchestrator's roster never empties on its own (exercises the backstop)."""
+
+    def receiveMsg_UserMessage(self, message: UserMessage, sender: ActorAddress) -> None:
+        _in_handler.set()
+
+    def stop(self) -> None:  # type: ignore[override]
+        # Swallow the stop: the actor keeps running, so its StopMessage never
+        # lands and get_team() never empties — only the backstop can finalize.
+        return None
+
+
+def _build_team(
+    system: ActorSystem, worker_cls: type[Akgent]
+) -> tuple[ActorAddress, ActorAddress, RecordingSubscriber]:
+    """Start an orchestrator + one child worker under it; return (orch, child, recorder)."""
+    _in_handler.clear()
+    orch_addr = system.createActor(
+        Orchestrator,
+        config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    recorder = RecordingSubscriber()
+    orch_proxy.subscribe(recorder)
+    child_addr = orch_proxy.createActor(
+        worker_cls, config=BaseConfig(name="@Worker", role="Worker")
+    )
+    assert child_addr is not None
+    return orch_addr, child_addr, recorder
+
+
+# ---------------------------------------------------------------------------
+# Ported reproduction (the two research tests, asserting the FIXED behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_during_processing_does_not_deadlock() -> None:
+    """DeadlockWorker calls get_team() mid-message; stop() is asked at that moment.
+
+    The returned event must be set within the test watchdog (no deadlock) and the
+    team must tear down. WATCHDOG bounds the *test*; GRACE is the backstop passed
+    to stop().
+    """
+    grace = 5.0
+    watchdog = 10.0
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, DeadlockWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0), "worker never entered its handler"
+
+    event: threading.Event = system.proxy_ask(orch_addr, Orchestrator).stop(grace)
+    assert event.wait(timeout=watchdog), "orchestrator.stop() deadlocked (event never set)"
+    assert not orch_addr.is_alive()
+
+
+def _processed_count_after_worker_stop(system: ActorSystem) -> int:
+    """Stop a TelemetryWorker while its message is in flight, then GC it, and
+    return how many ProcessedMessages the (still-alive) orchestrator recorded.
+
+    Stopping only the worker (blocking child stop) keeps the orchestrator alive
+    so we can query its history. The orchestrator's GC-safe identity guard
+    (ADR-012 §5) must not throw when it drains the late ProcessedMessage from the
+    now-collected worker — otherwise the message is dropped (research §3.1).
+    """
+    orch_addr, child_addr, _ = _build_team(system, TelemetryWorker)
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0), "worker never entered its handler"
+
+    # Blocking stop of the worker only (no deadlock: TelemetryWorker never
+    # re-enters the orchestrator). The worker emits its ProcessedMessage right as
+    # it is torn down.
+    system.proxy_ask(child_addr, Akgent).stop()
+    del child_addr
+    gc.collect()  # promptly collect the stopped worker, surfacing the §3.1 race
+    time.sleep(0.3)  # let the orchestrator drain the queued ProcessedMessage
+
+    from akgentic.core.messages.orchestrator import ProcessedMessage
+
+    recorded = system.proxy_ask(orch_addr, Orchestrator).get_messages(
+        message_type=ProcessedMessage
+    )
+    return len(recorded)
+
+
+def test_processed_telemetry_survives_agent_stop() -> None:
+    """Every in-flight message's ProcessedMessage is recorded even when the
+    emitting agent is stopped + GC'd right after (GC-safe identity — research §3.1).
+
+    Loops N=25 because the loss was a GC race; the orchestrator must record the
+    ProcessedMessage on EVERY run.
+    """
+    runs = 25
+    losses: list[int] = []
+    for i in range(runs):
+        system = ActorSystem()
+        if _processed_count_after_worker_stop(system) < 1:
+            losses.append(i)
+
+    assert not losses, f"ProcessedMessage telemetry LOST in {len(losses)}/{runs} runs ({losses})"
+
+
+# ---------------------------------------------------------------------------
+# Behaviour matrix
+# ---------------------------------------------------------------------------
+
+
+def test_stop_returns_event_immediately() -> None:
+    """stop() returns a threading.Event, unset on return, with the orchestrator
+    thread free (a concurrent get_team() ask resolves before the event is set)."""
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, DeadlockWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    event = system.proxy_ask(orch_addr, Orchestrator).stop(5.0)
+    assert isinstance(event, threading.Event)
+    assert not event.is_set()  # returned before teardown completed
+
+    # The orchestrator thread is free: a reentrant ask resolves while draining.
+    roster = system.proxy_ask(orch_addr, Orchestrator).get_team()
+    assert isinstance(roster, list)
+
+    assert event.wait(timeout=10.0)
+
+
+def test_stop_is_idempotent() -> None:
+    """Two stop() calls return the SAME event; children are told once."""
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, TelemetryWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    proxy = system.proxy_ask(orch_addr, Orchestrator)
+    first = proxy.stop(5.0)
+    second = proxy.stop(5.0)
+    assert first is second
+
+    assert first.wait(timeout=10.0)
+
+
+def test_zero_children_team_finalizes() -> None:
+    """An orchestrator with no agents sets the event promptly."""
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+
+    event = system.proxy_ask(orch_addr, Orchestrator).stop(5.0)
+    assert event.wait(timeout=5.0)
+    assert not orch_addr.is_alive()
+
+
+def test_backstop_timeout_forces_finalize(caplog: pytest.LogCaptureFixture) -> None:
+    """A wedged child that never stops → with a small grace_timeout the backstop
+    fires → the event is set within ~grace_timeout, with a WARNING logged."""
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, WedgedWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+    time.sleep(_HANDLER_HOLD_S + 0.1)  # let the handler finish so child is idle but alive
+
+    grace = 1.0
+    with caplog.at_level(logging.WARNING):
+        event = system.proxy_ask(orch_addr, Orchestrator).stop(grace)
+        # Event must NOT set before the grace period (child is wedged).
+        assert not event.wait(timeout=0.3)
+        # But the backstop sets it within ~grace.
+        assert event.wait(timeout=grace + 5.0)
+
+    assert any("forcing teardown" in rec.message for rec in caplog.records)
+
+
+def test_get_team_safe_after_member_gc() -> None:
+    """With a stopped+GC'd member recorded in messages, get_team() (driven during
+    _stopping) returns the correct roster and raises no RuntimeError.
+
+    The orchestrator's teardown completion check calls get_team() over every
+    Start/Stop sender, including senders whose actor has already been collected.
+    A clean event-set proves the completion check did not throw mid-teardown.
+    """
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, TelemetryWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+    time.sleep(_HANDLER_HOLD_S + 0.1)
+
+    # Drop our reference so the member can be collected as teardown drains.
+    del child_addr
+    gc.collect()
+
+    event = system.proxy_ask(orch_addr, Orchestrator).stop(5.0)
+    assert event.wait(timeout=10.0)
+    assert not orch_addr.is_alive()
+
+
+def test_actor_address_identity_survives_gc() -> None:
+    """After the actor is collected, agent_id / role / __eq__ / __hash__ still
+    work; name / serialize() behave as documented (live-resolving)."""
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    addr = system.createActor(
+        Akgent, config=BaseConfig(name="@Solo", role="Worker"), team_id=orch_addr.team_id
+    )
+    impl = ActorAddressImpl(addr._actor_ref)  # type: ignore[attr-defined]
+    twin = ActorAddressImpl(addr._actor_ref)  # type: ignore[attr-defined]
+
+    cached_id = impl.agent_id
+    cached_role = impl.role
+
+    # Stop + collect the underlying actor.
+    addr._actor_ref.stop(block=True)  # type: ignore[attr-defined]
+    del addr
+    gc.collect()
+
+    # Cached identity survives GC.
+    assert impl.agent_id == cached_id
+    assert impl.role == cached_role
+    assert impl == twin  # __eq__ works post-GC (reads cached agent_id)
+    assert hash(impl) == hash(cached_id)
+
+    # name / serialize() remain live-resolving → raise on a collected actor.
+    with pytest.raises(RuntimeError):
+        _ = impl.name
+    with pytest.raises(RuntimeError):
+        _ = impl.serialize()
+
+
+def test_agent_stop_still_blocking() -> None:
+    """A non-orchestrator Akgent.stop() returns None and blocks until children
+    are down (asymmetry regression guard)."""
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    parent = orch_proxy.createActor(Akgent, config=BaseConfig(name="@Parent", role="Worker"))
+    child = system.proxy_ask(parent, Akgent).createActor(
+        Akgent, config=BaseConfig(name="@Child", role="Worker")
+    )
+
+    result = system.proxy_ask(parent, Akgent).stop()
+    assert result is None
+    # Blocking stop means the subtree is down on the next line.
+    assert not parent.is_alive()
+    assert not child.is_alive()
+
+
+def test_stop_events_suppressed_from_subscribers_during_teardown() -> None:
+    """During _stopping, StopMessages are appended to messages but NOT delivered
+    to subscribers."""
+    system = ActorSystem()
+    orch_addr, child_addr, recorder = _build_team(system, TelemetryWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    system.proxy_ask(orch_addr, Orchestrator).stop(5.0).wait()
+
+    # No StopMessage should have reached the subscriber (suppressed during teardown).
+    assert recorder.type_counts()["StopMessage"] == 0
+
+
+def test_shutdown_waits_on_orchestrator_events() -> None:
+    """ActorSystem.shutdown() returns only after every orchestrator's event is set;
+    no force-kill needed on the happy path."""
+    system = ActorSystem()
+    orch_addr, child_addr, _ = _build_team(system, TelemetryWorker)
+
+    system.tell(child_addr, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    system.shutdown(timeout=10)
+
+    # shutdown returned → every orchestrator finalized.
+    assert not orch_addr.is_alive()
+    assert len(system.orchestrators) == 0


### PR DESCRIPTION
# Epic 18 — Non-Blocking Orchestrator Stop

Implements ADR-012: make `Orchestrator.stop()` non-blocking so a child re-entering the orchestrator mid-message (`get_team()`) can never deadlock the stop. `stop()` tells children to stop and returns a `threading.Event` set when the orchestrator is fully stopped; callers wait on the event off the actor thread.

## Stories

- [x] 18-1-non-blocking-orchestrator-stop — non-blocking orchestrator stop (Relates to #77)

## Review status

**18-1-non-blocking-orchestrator-stop — APPROVED (done).** Reviewed the whole-story commit `c6a52ec` against ADR-012 and the Golden Rules. All six acceptance criteria are faithfully implemented:

- **AC1** `Akgent.stop_children(blocking)` extracts the recursive teardown; `Akgent.stop()` stays blocking (asymmetry preserved). `_stopping` initialised in `__init__`.
- **AC2** `Orchestrator.stop(grace_timeout) -> threading.Event` is non-blocking, idempotent (same event, no re-tell), arms the backstop with `grace_timeout`, finalizes immediately for a zero-agent team, returns the event without waiting. Docstring states the single-timeout contract and wait-with-no-timeout guidance.
- **AC3** `receiveMsg_StopMessage` appends + invalidates the roster cache even while `_stopping`, finalizes when `get_team()` empties, and suppresses subscriber dispatch during teardown (preserves XADD-before-DEL ordering).
- **AC4** `on_stop` cancels the backstop and sets the event (idempotent). `_finalize_stop`/`_force_stop` both use the native `actor_ref.stop(block=False)` — never `super().stop()` — so neither re-enters `stop_children` on a non-actor thread. `STOP_TIMEOUT` module constant added.
- **AC5** `ActorAddressImpl` caches `agent_id` + `role` eagerly in `__init__`; both properties fall back to live resolve when unset; `__eq__`/`__hash__` GC-safe for free. `name`/`team_id`/`squad_id`/`serialize()` stay live-resolving.
- **AC6** `ActorSystem.shutdown` issues the non-blocking `stop(grace)` for all orchestrators first, then waits on each event with no timeout; `ActorRegistry.stop_all()` stays as last-resort force-kill.

A noteworthy correctness improvement beyond the literal ADR text: `get_team()` now self-excludes the orchestrator by **identity** (`agent_id != self.agent_id`) rather than by the `"Orchestrator"` role string — robust against a self carrying a non-orchestrator role and against legitimate sub-orchestrator members. No fix-worthy issues found; **no review fixup commit was needed.**

## Epic 18 slice complete

This is the only and final story in Epic 18 — the epic's `akgentic-core` slice is complete. The deterministic deadlock reproduction was ported from the `akgentic-team` research artifact into the CI suite (`tests/core/test_orchestrator_stop.py`, 11 behaviour tests), plus a `--timeout=300 --timeout-method=thread` pytest backstop so a stop-path regression fails fast instead of hanging the suite. Downstream caller migration (`akgentic-team` ADR-19, `.stop(grace).wait()`) is a separate submodule story, gated on this landing on `akgentic-core/master`.

Local gate (project preference: local green is the gate):
- `pytest packages/akgentic-core/tests/` — **495 passed**
- `mypy packages/akgentic-core/src/` — clean
- `ruff check packages/akgentic-core/src/` — clean

## Scope guard

All changes stay inside `packages/akgentic-core/` (src + tests + pyproject). No other submodule is touched — verified against the commit. Golden Rule #4 satisfied. No `ADR-NNN` test assertions or code branches (Golden Rule #8); the single `ADR-012` reference in source is an inline navigation comment, which is allowed.

Closes #77
