### PR TITLE
feat(akgentic-core): 6-4 resilient ActorAddressImpl

### DIFF
--- a/src/akgentic/core/actor_address_impl.py
+++ b/src/akgentic/core/actor_address_impl.py
@@ -24,15 +24,28 @@ if TYPE_CHECKING:
 
 
 class ActorAddressImpl(ActorAddress):
-    """ActorAddress wrapping a live Pykka ActorRef.
+    """ActorAddress wrapping a live Pykka ActorRef — a resilient snapshot.
 
-    Provides access to agent metadata by reading from the underlying actor
-    instance. Used for local in-memory actor communication.
+    An ``ActorAddressImpl`` is a **point-in-time snapshot** of an actor's
+    identity and metadata (ADR-013). Because the Pykka 4.4.2+ ``ActorRef`` holds
+    only a *weakref* to the underlying actor (ADR-003), an address can outlive
+    its actor: the actor is garbage-collected while the address lives on in
+    orchestrator history, queued telemetry, or subscriber snapshots.
+
+    To make that lifecycle safe, **all** metadata (``agent_id``, ``name``,
+    ``role``, ``team_id``, ``squad_id``, the actor ``type`` and the
+    ``user_message`` flag) is captured into private vars at construction. Every
+    accessor, ``serialize()`` and ``__repr__`` read the cache — reading metadata
+    or checking liveness NEVER raises on a collected actor. The live
+    ``_actor_ref`` is retained for message *delivery* only (``send`` /
+    ``proxy``).
 
     Note:
-        This implementation accesses the Pykka 4.4.2+ weakref API
-        (_actor_ref._actor_weakref) to dereference the underlying actor.
-        Direct property access on a GC'd actor raises RuntimeError.
+        Metadata reflects the actor's state at construction time, not a live
+        view. If an actor's ``config`` is mutated after an address is built, an
+        address constructed earlier keeps the old value. Addresses are
+        short-lived (built per-send via ``myAddress``), so this snapshot
+        semantics is correct for the dominant use.
 
     Args:
         actor_ref: The Pykka ActorRef to wrap.
@@ -45,110 +58,92 @@ class ActorAddressImpl(ActorAddress):
     """
 
     def __init__(self, actor_ref: ActorRef[Any]) -> None:
-        """Initialize with a Pykka ActorRef.
+        """Initialize with a Pykka ActorRef, caching all metadata (ADR-013 §1).
 
-        Caches the address *identity* (``agent_id`` and ``role``) eagerly at
-        construction (ADR-012 §5). Addresses are only ever built from live refs,
-        so the underlying actor is alive here; caching makes ``agent_id``,
-        ``role``, ``__eq__`` and ``__hash__`` survive the actor's garbage
-        collection — required so ``get_team()`` and the telemetry identity guards
-        stay safe during teardown over already-collected senders.
+        Addresses are only ever built from a live ref (``myAddress``,
+        ``createActor``, ``ActorSystem`` lookups), so the underlying actor is
+        alive here. Capture everything the address will ever need — identity,
+        config metadata, the actor type and the user-message flag — so every
+        later read survives the actor's garbage collection.
+
+        The capture is wrapped: an already-dead ref at construction (rare) leaves
+        a safe snapshot (``None``/``False``) rather than raising.
 
         Args:
-            actor_ref: The Pykka ActorRef to wrap.
+            actor_ref: The Pykka ActorRef to wrap. Retained for delivery only.
         """
         self._actor_ref = actor_ref
         self._agent_id: uuid.UUID | None = None
+        self._name: str | None = None
         self._role: str | None = None
+        self._team_id: uuid.UUID | None = None
+        self._squad_id: uuid.UUID | None = None
+        self._actor_type: type[Any] | None = None
+        self._user_message: bool = False
         try:
             actor = actor_ref._actor_weakref()
             if actor is not None:
                 self._agent_id = actor.agent_id
+                self._name = actor.config.name
                 self._role = actor.config.role
+                self._team_id = actor.team_id
+                self._squad_id = actor.config.squad_id
+                self._actor_type = type(actor)
+                self._user_message = callable(getattr(actor, "receiveMsg_UserMessage", None))
         except Exception:  # noqa: BLE001
-            # Identity stays unset → properties fall back to live resolve.
-            self._agent_id = None
-            self._role = None
-
-    def _resolve_actor(self) -> Any:
-        """Dereference the weak reference to the underlying actor.
-
-        Returns:
-            The live actor instance.
-
-        Raises:
-            RuntimeError: If the actor has been garbage collected.
-        """
-        actor = self._actor_ref._actor_weakref()
-        if actor is None:
-            raise RuntimeError(f"Actor {self._actor_ref.actor_urn} has been garbage collected")
-        return actor
+            # Already-dead ref at construction (rare): keep the safe snapshot.
+            pass
 
     @property
     def agent_id(self) -> uuid.UUID:
-        """Unique identifier (cached at construction; GC-safe — ADR-012 §5).
-
-        Returns the cached identity if available, falling back to a live resolve
-        only when the cache is unset.
+        """Unique identifier (cached at construction; GC-safe — ADR-013 §2).
 
         Returns:
-            UUID from the actor's agent_id attribute.
+            UUID captured from the actor's ``agent_id`` at construction.
         """
-        if self._agent_id is not None:
-            return self._agent_id
-        return self._resolve_actor().agent_id  # type: ignore[no-any-return]
+        return self._agent_id  # type: ignore[return-value]
 
     @property
     def name(self) -> str:
-        """Agent name from the underlying actor's config.
+        """Agent name (cached at construction; GC-safe — ADR-013 §2).
 
         Returns:
-            Name string from config, or string representation of actor_ref as fallback.
+            Name string captured from ``config.name`` at construction.
         """
-        actor = self._resolve_actor()
-        return actor.config.name  # type: ignore[no-any-return]
+        return self._name  # type: ignore[return-value]
 
     @property
     def role(self) -> str:
-        """Agent role (cached at construction; GC-safe — ADR-012 §5).
-
-        Returns the cached identity if available, falling back to a live resolve
-        only when the cache is unset. Role is fixed after construction for all
-        current agents, so caching it is safe.
+        """Agent role (cached at construction; GC-safe — ADR-013 §2).
 
         Returns:
-            Role string from config, or class name as fallback.
+            Role string captured from ``config.role`` at construction.
         """
-        if self._role is not None:
-            return self._role
-        actor = self._resolve_actor()
-        return actor.config.role  # type: ignore[no-any-return]
+        return self._role  # type: ignore[return-value]
 
     @property
     def team_id(self) -> uuid.UUID:
-        """Team identifier from the underlying actor.
+        """Team identifier (cached at construction; GC-safe — ADR-013 §2).
 
         Returns:
-            UUID from team_id.
+            UUID captured from the actor's ``team_id`` at construction.
         """
-        actor = self._resolve_actor()
-        return actor.team_id  # type: ignore[no-any-return]
+        return self._team_id  # type: ignore[return-value]
 
     @property
     def squad_id(self) -> uuid.UUID | None:
-        """Squad identifier from the underlying actor's config.
+        """Squad identifier (cached at construction; GC-safe — ADR-013 §2).
 
         Returns:
-            UUID from config.squad_id, or None if not available.
+            UUID captured from ``config.squad_id`` at construction, or None.
         """
-        actor = self._resolve_actor()
-        return actor.config.squad_id  # type: ignore[no-any-return]
+        return self._squad_id
 
     def send(self, recipient: ActorAddress, message: Any) -> None:
         """Send a message via Pykka proxy.
 
-        Uses the actor's send method via proxy to deliver the message.
-        Blocks until the message is delivered.
+        Uses the live ``_actor_ref`` — the one operation that genuinely needs
+        the live actor (ADR-013 §4). Blocks until the message is delivered.
 
         Args:
             recipient: The intended recipient of the message.
@@ -157,49 +152,55 @@ class ActorAddressImpl(ActorAddress):
         self._actor_ref.proxy().send(recipient, message).get()
 
     def is_alive(self) -> bool:
-        """Check if the underlying actor is still running.
+        """Check if the underlying actor is still running (never raises).
+
+        Liveness is best-effort: a torn-down or collected ref is simply
+        "not alive" (ADR-013 §3).
 
         Returns:
-            True if the Pykka actor is alive.
+            True if the Pykka actor is alive; False on any exception.
         """
-        return self._actor_ref.is_alive()
+        try:
+            return self._actor_ref.is_alive()
+        except Exception:  # noqa: BLE001 — a torn-down/collected ref is not alive
+            return False
 
     def handle_user_message(self) -> bool:
-        """Check if the agent accepts user messages.
-
-        Checks for the existence of a receiveMsg_UserMessage method on the actor.
+        """Check if the agent accepts user messages (cached; GC-safe).
 
         Returns:
-            True if the actor has a receiveMsg_UserMessage method.
+            True if the actor had a ``receiveMsg_UserMessage`` method at
+            construction.
         """
-        actor = self._resolve_actor()
-        accept_method = getattr(actor, "receiveMsg_UserMessage", None)
-        return callable(accept_method)
+        return self._user_message
 
     def serialize(self) -> ActorAddressDict:
-        """Serialize to dictionary for transport.
+        """Serialize to dictionary for transport (composed from the cache).
 
-        Captures all metadata from the live actor for reconstruction.
-        The __actor_type__ is set to the actual agent class, not the address wrapper.
+        Composes the dict on demand from the cached values — never touches the
+        weakref (ADR-013 §2), so a stopped + GC'd address serializes cleanly.
+        The ``__actor_type__`` is the actual agent class, not the address wrapper.
 
         Returns:
-            ActorAddressDict with all actor metadata.
+            ActorAddressDict with all cached actor metadata.
         """
-        agent_type = self._resolve_actor().__class__
+        actor_type = self._actor_type
         return {
             "__actor_address__": True,
-            "__actor_type__": f"{agent_type.__module__}.{agent_type.__name__}",
-            "agent_id": str(self.agent_id),
-            "name": self.name,
-            "role": self.role,
-            "team_id": str(self.team_id),
-            "squad_id": str(self.squad_id) if self.squad_id is not None else "",
-            "user_message": self.handle_user_message(),
+            "__actor_type__": (
+                f"{actor_type.__module__}.{actor_type.__name__}" if actor_type else ""
+            ),
+            "agent_id": str(self._agent_id) if self._agent_id is not None else "",
+            "name": self._name or "",
+            "role": self._role or "",
+            "team_id": str(self._team_id) if self._team_id is not None else "",
+            "squad_id": str(self._squad_id) if self._squad_id is not None else "",
+            "user_message": self._user_message,
         }
 
     def __repr__(self) -> str:
-        """String representation for debugging."""
-        return f"<ActorAddress {self.role} {self.name} ({self.agent_id})>"
+        """String representation for debugging (reads the cache)."""
+        return f"<ActorAddress {self._role} {self._name} ({self._agent_id})>"
 
     def __eq__(self, other: object) -> bool:
         """Compare addresses by agent_id (same class only)."""

--- a/tests/core/test_actor_address.py
+++ b/tests/core/test_actor_address.py
@@ -129,17 +129,19 @@ class TestActorAddressImpl:
         config.role = "assistant"
         config.squad_id = uuid.UUID("11111111-2222-3333-4444-555555555555")
 
-        # Create actor with flat public attributes (post-7-1 rename)
-        actor = MagicMock()
+        # Create a real actor instance so ``type(actor)`` (ADR-013 §1 caches the
+        # actor type at construction) resolves to the intended agent class for the
+        # serialize ``__actor_type__`` check.
+        mock_agent_cls = type(
+            "MockAgent", (), {"__module__": "test.agents"}
+        )
+        actor = mock_agent_cls()
+        # Flat public attributes (post-7-1 rename)
         actor.agent_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
         actor.config = config
         actor.team_id = uuid.UUID("87654321-4321-8765-4321-876543218765")
         # Add receiveMsg_UserMessage method for handle_user_message check
         actor.receiveMsg_UserMessage = MagicMock()
-        # Set __class__ for serialize test
-        actor.__class__ = type(
-            "MockAgent", (), {"__module__": "test.agents", "__name__": "MockAgent"}
-        )
 
         actor_ref = MagicMock()
         # pykka 4.4.2+: _actor_weakref() returns the actor (callable, not attribute)
@@ -188,8 +190,10 @@ class TestActorAddressImpl:
         """handle_user_message should return False when receiveMsg_UserMessage is absent."""
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
-        # Use spec to prevent MagicMock from auto-creating receiveMsg_UserMessage
-        limited_actor = MagicMock(spec=["agent_id", "config"])
+        # Use spec to prevent MagicMock from auto-creating receiveMsg_UserMessage,
+        # while keeping every metadata attribute the constructor snapshots so the
+        # cache captures cleanly and only the user-message flag resolves to False.
+        limited_actor = MagicMock(spec=["agent_id", "config", "team_id"])
         mock_actor_ref._actor_weakref = lambda: limited_actor
 
         impl = ActorAddressImpl(mock_actor_ref)
@@ -213,17 +217,32 @@ class TestActorAddressImpl:
         assert serialized["squad_id"] == str(actor.config.squad_id)
         assert serialized["user_message"] is True
 
-    def test_resolve_actor_raises_on_gc(self, mock_actor_ref: MagicMock) -> None:
-        """_resolve_actor raises RuntimeError containing the actor URN when weakref returns None."""
+    def test_dead_ref_at_construction_leaves_safe_snapshot(
+        self, mock_actor_ref: MagicMock
+    ) -> None:
+        """An already-dead ref at construction yields a safe snapshot, never raises.
+
+        Snapshot semantics (ADR-013): metadata is captured at construction. If the
+        weakref is already None when the address is built (rare), the accessors
+        return the safe defaults (None/False) instead of raising RuntimeError.
+        """
         from akgentic.core.actor_address_impl import ActorAddressImpl
 
-        # Simulate GC'd actor: weakref returns None
+        # Simulate a ref whose actor is already gone at construction time.
         mock_actor_ref._actor_weakref = lambda: None
         mock_actor_ref.actor_urn = "urn:mock:gc-actor"
 
         impl = ActorAddressImpl(mock_actor_ref)
-        with pytest.raises(RuntimeError, match="urn:mock:gc-actor"):
-            _ = impl.agent_id
+        # No RuntimeError on any read — everything falls back to the safe snapshot.
+        assert impl.agent_id is None
+        assert impl.name is None
+        assert impl.role is None
+        assert impl.team_id is None
+        assert impl.squad_id is None
+        assert impl.handle_user_message() is False
+        serialized = impl.serialize()
+        assert serialized["__actor_type__"] == ""
+        assert serialized["agent_id"] == ""
 
     def test_equality_and_hashing(self, mock_actor_ref: MagicMock) -> None:
         """Equality and hash should be based on agent_id."""
@@ -233,3 +252,102 @@ class TestActorAddressImpl:
         impl2 = ActorAddressImpl(mock_actor_ref)
         assert impl1 == impl2
         assert hash(impl1) == hash(impl2)
+
+    def test_metadata_reflects_construction_snapshot(self, mock_actor_ref: MagicMock) -> None:
+        """Metadata is a snapshot captured at construction, not a live view (ADR-013).
+
+        An address built earlier keeps the values it captured even after the
+        underlying actor's config is mutated. This documents the
+        snapshot-not-live semantics: reads never re-resolve the actor.
+        """
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+
+        actor = mock_actor_ref._actor_weakref()
+        impl = ActorAddressImpl(mock_actor_ref)
+        captured_name = impl.name
+        captured_role = impl.role
+
+        # Mutate the live actor's config AFTER the address was built.
+        actor.config.name = "renamed-agent"
+        actor.config.role = "renamed-role"
+
+        # The address keeps its construction-time snapshot — it does not track
+        # later mutations.
+        assert impl.name == captured_name == "mock-agent"
+        assert impl.role == captured_role == "assistant"
+
+
+class TestActorAddressImplResilientAfterGC:
+    """ActorAddressImpl reads survive a real actor being stopped and GC-collected.
+
+    Uses real ``akgentic-core`` actors (no mocks) so the Pykka 4.4.2+ weakref is
+    genuinely cleared by ``gc.collect()`` after the actor stops. All assertions
+    are behaviour-only (Golden Rule #8).
+    """
+
+    @staticmethod
+    def _build_dead_address() -> "ActorAddressImpl":  # type: ignore[name-defined]  # noqa: F821
+        """Create an actor, capture its address, then stop + GC the actor.
+
+        Returns an ``ActorAddressImpl`` whose underlying actor has been collected
+        (its weakref now resolves to None), plus the metadata captured before
+        teardown is verified by the caller via the returned address only.
+        """
+        import gc
+
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+        from akgentic.core.actor_system_impl import ActorSystem
+        from akgentic.core.agent import Akgent
+        from akgentic.core.agent_config import BaseConfig
+
+        squad = uuid.uuid4()
+        system = ActorSystem()
+        address = system.createActor(
+            Akgent,
+            config=BaseConfig(name="gc-agent", role="worker", squad_id=squad),
+        )
+        assert isinstance(address, ActorAddressImpl)
+
+        # Stop the actor and drop every strong reference, then force collection so
+        # the ActorRef's weakref resolves to None.
+        system.proxy_ask(address, Akgent).stop()
+        system.shutdown()
+        gc.collect()
+        return address
+
+    def test_metadata_survives_actor_gc(self) -> None:
+        """All metadata accessors return captured values after stop + GC (no raise)."""
+        address = self._build_dead_address()
+        assert address.name == "gc-agent"
+        assert address.role == "worker"
+        assert isinstance(address.agent_id, uuid.UUID)
+        assert isinstance(address.team_id, uuid.UUID)
+        assert isinstance(address.squad_id, uuid.UUID)
+        # Base Akgent has no receiveMsg_UserMessage handler.
+        assert address.handle_user_message() is False
+
+    def test_serialize_survives_actor_gc(self) -> None:
+        """serialize() returns the full dict after stop + GC (the §3.1 serialize case)."""
+        address = self._build_dead_address()
+        serialized = address.serialize()
+        assert serialized["__actor_address__"] is True
+        assert serialized["__actor_type__"].endswith(".Akgent")
+        assert serialized["name"] == "gc-agent"
+        assert serialized["role"] == "worker"
+        assert serialized["agent_id"] != ""
+        assert serialized["team_id"] != ""
+        assert serialized["squad_id"] != ""
+        assert serialized["user_message"] is False
+
+    def test_is_alive_false_after_gc(self) -> None:
+        """is_alive() returns False (not raises) after stop + GC."""
+        address = self._build_dead_address()
+        assert address.is_alive() is False
+
+    def test_eq_hash_survive_gc(self) -> None:
+        """__eq__ / __hash__ keep working after stop + GC (cached agent_id)."""
+        address = self._build_dead_address()
+        # Self-equality and hashability both rely on the cached agent_id.
+        assert address == address
+        assert hash(address) == hash(address.agent_id)
+        assert len({address, address}) == 1

--- a/tests/core/test_orchestrator_stop.py
+++ b/tests/core/test_orchestrator_stop.py
@@ -291,9 +291,14 @@ def test_get_team_safe_after_member_gc() -> None:
     assert not orch_addr.is_alive()
 
 
-def test_actor_address_identity_survives_gc() -> None:
-    """After the actor is collected, agent_id / role / __eq__ / __hash__ still
-    work; name / serialize() behave as documented (live-resolving)."""
+def test_actor_address_metadata_survives_gc() -> None:
+    """After the actor is collected, EVERY metadata read and serialize() return
+    the construction-time snapshot with no RuntimeError (ADR-013).
+
+    This generalises the earlier agent_id/role-only guarantee: name, team_id,
+    squad_id, handle_user_message() and serialize() are now equally GC-safe, and
+    is_alive() returns False instead of raising.
+    """
     system = ActorSystem()
     orch_addr = system.createActor(
         Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
@@ -306,6 +311,7 @@ def test_actor_address_identity_survives_gc() -> None:
 
     cached_id = impl.agent_id
     cached_role = impl.role
+    cached_name = impl.name
 
     # Stop + collect the underlying actor.
     addr._actor_ref.stop(block=True)  # type: ignore[attr-defined]
@@ -318,11 +324,13 @@ def test_actor_address_identity_survives_gc() -> None:
     assert impl == twin  # __eq__ works post-GC (reads cached agent_id)
     assert hash(impl) == hash(cached_id)
 
-    # name / serialize() remain live-resolving → raise on a collected actor.
-    with pytest.raises(RuntimeError):
-        _ = impl.name
-    with pytest.raises(RuntimeError):
-        _ = impl.serialize()
+    # name / serialize() are now snapshot-backed → resilient on a collected actor.
+    assert impl.name == cached_name == "@Solo"
+    assert impl.is_alive() is False
+    serialized = impl.serialize()
+    assert serialized["name"] == "@Solo"
+    assert serialized["role"] == "Worker"
+    assert serialized["__actor_type__"].endswith(".Akgent")
 
 
 def test_agent_stop_still_blocking() -> None:
@@ -374,3 +382,47 @@ def test_shutdown_waits_on_orchestrator_events() -> None:
     # shutdown returned → every orchestrator finalized.
     assert not orch_addr.is_alive()
     assert len(system.orchestrators) == 0
+
+
+def test_subscriber_snapshots_gcd_telemetry_sender() -> None:
+    """A late ProcessedMessage whose sender has been stopped + GC'd is snapshotted
+    for subscribers without crashing (the §3.1 serialize() case).
+
+    Drives the exact production entry point — ``Orchestrator.snapshot_for_subscribers``
+    → ``snapshot_addresses`` → ``ActorAddressImpl.serialize()``. Before ADR-013 the
+    serialize resolved the now-collected sender and threw, dropping the message; with
+    the resilient snapshot it composes from the cache, yielding a populated proxy.
+    """
+    from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+    from akgentic.core.messages.orchestrator import ProcessedMessage
+
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+
+    # Build a sender address from a short-lived worker, then stop + GC it so the
+    # sender's underlying actor is gone by the time the message is snapshotted.
+    worker_addr = orch_proxy.createActor(
+        TelemetryWorker, config=BaseConfig(name="@Telemetry", role="Worker")
+    )
+    sender = ActorAddressImpl(worker_addr._actor_ref)  # type: ignore[attr-defined]
+    system.proxy_ask(worker_addr, Akgent).stop()
+    del worker_addr
+    gc.collect()
+    assert sender.is_alive() is False  # underlying actor collected
+
+    # A late telemetry message whose sender is the now-collected worker.
+    late = ProcessedMessage(sender=sender, recipient=orch_addr, message_id=uuid.uuid4())
+
+    # The subscriber-snapshot step must NOT raise on the GC'd sender.
+    snapshot = Orchestrator.snapshot_for_subscribers(late)
+
+    # The snapshot carries a serialized proxy of the dead sender, not the live impl.
+    assert isinstance(snapshot.sender, ActorAddressProxy)
+    assert snapshot.sender.name == "@Telemetry"
+    assert snapshot.sender.role == "Worker"
+    assert snapshot.sender.serialize()["__actor_type__"].endswith(".TelemetryWorker")
+
+    system.shutdown()


### PR DESCRIPTION
## Summary

Makes `ActorAddressImpl` a **resilient, point-in-time snapshot** of an actor's identity and metadata. Because the Pykka 4.4.2+ `ActorRef` holds only a weakref to the actor, an address can outlive its actor (it lives on in orchestrator history, queued telemetry, and subscriber snapshots). Previously most accessors live-resolved the actor on every read and raised `RuntimeError` once it was garbage-collected. This story caches all metadata at construction so every metadata read and the liveness check NEVER raise on a collected actor — the live ref is retained for message delivery only.

Closes #79.

## ADR-013 conformance

- **§1 — cache at construction:** `__init__` captures `agent_id`, `name`, `role`, `team_id`, `squad_id`, the actor `type` (for `__actor_type__`), and the `user_message` flag (`callable(getattr(actor, "receiveMsg_UserMessage", None))`) into private vars, wrapped in a `try/except` so an already-dead ref at construction leaves a safe snapshot (`None`/`False`) rather than raising.
- **§2 — accessors read the cache:** `agent_id`/`name`/`role`/`team_id`/`squad_id`/`handle_user_message()` return cached values; `serialize()` composes its dict on demand from the cache (no eager dict at construction, no live resolution); `__repr__` reads the cache. `_resolve_actor()` is removed entirely — gone from the read path.
- **§3 — `is_alive()` never raises:** wraps `self._actor_ref.is_alive()` in `try/except`, returning `False` on any exception.
- **§4 — live ref only for delivery:** `_actor_ref` is dereferenced only by `send()`/`proxy()`; no metadata/identity/liveness read touches the weakref.
- **§5 — unchanged:** `ActorAddressProxy` / `ActorAddressStopped` are dict-backed and already resilient — untouched.

## Snapshot-not-live behaviour change + the two updated tests

The behaviour change is that metadata reflects the actor's state **at construction time**, not a live view. Two pre-existing tests asserted the OLD live-resolve *raise* behaviour and were rewritten to assert the new resilient snapshot behaviour (no coverage weakened — raise-assertions replaced with full metadata + `serialize()` + `is_alive()` assertions):

- `test_orchestrator_stop.py`: `test_actor_address_identity_survives_gc` → `test_actor_address_metadata_survives_gc`. Was: `name`/`serialize()` raise `RuntimeError` on a collected actor. Now: every accessor + `serialize()` return the construction-time snapshot and `is_alive()` returns `False`.
- `test_actor_address.py`: `test_resolve_actor_raises_on_gc` → `test_dead_ref_at_construction_leaves_safe_snapshot`. Was: `agent_id` raises `RuntimeError` when the weakref is `None`. Now: an already-dead ref at construction yields a safe snapshot (`None`/`False`, empty serialize fields), never raises.

New tests: `TestActorAddressImplResilientAfterGC` (metadata/serialize/is_alive/eq-hash survive a real actor stop+GC) and `test_metadata_reflects_construction_snapshot` (documents the snapshot-not-live semantics).

## §3.1 serialize-gap closure

`test_subscriber_snapshots_gcd_telemetry_sender` drives the exact production entry point — `Orchestrator.snapshot_for_subscribers` → `snapshot_addresses` → `ActorAddressImpl.serialize()` — for a late `ProcessedMessage` whose sender has been stopped + GC'd. Before this story the serialize resolved the collected sender and threw, dropping the message; now it composes from the cache and yields a populated `ActorAddressProxy`. This closes the `serialize()`-on-GC half of the §3.1 telemetry race left open by ADR-012 §5.

## Scope guard

All changes are confined to `packages/akgentic-core/`:
- `src/akgentic/core/actor_address_impl.py`
- `tests/core/test_actor_address.py`
- `tests/core/test_orchestrator_stop.py`

## Verification

`pytest packages/akgentic-core/tests/` → 501 passed; `mypy packages/akgentic-core/src/` → clean (17 files); `ruff check packages/akgentic-core/src/` → clean. Behaviour-only assertions (no ADR-string assertions).
