### PR TITLE
test(akgentic-core): 18-2 characterize teardown recipient-resolution race

### DIFF
--- a/tests/core/test_orchestrator_stop.py
+++ b/tests/core/test_orchestrator_stop.py
@@ -103,6 +103,22 @@ class WedgedWorker(Akgent):
         return None
 
 
+class ProbingOrchestrator(Orchestrator):
+    """Orchestrator that exposes the teardown-window roster lookup on its actor thread.
+
+    ``probe_lookup_during_stopping`` runs inside the orchestrator's own message
+    loop (driven via ``proxy_ask``), so it observes the same shrinking roster a
+    mid-handler agent's reentrant ``get_team_member()`` would see while the team
+    is being torn down. It only flips ``_stopping`` and reads the roster — it
+    initiates no teardown — so the orchestrator stays alive for the assertion.
+    """
+
+    def probe_lookup_during_stopping(self, *names: str) -> list[ActorAddress | None]:
+        self._stopping = True
+        self._current_team_members = None  # force a fresh roster read
+        return [self.get_team_member(name) for name in names]
+
+
 def _build_team(
     system: ActorSystem, worker_cls: type[Akgent]
 ) -> tuple[ActorAddress, ActorAddress, RecordingSubscriber]:
@@ -374,3 +390,67 @@ def test_shutdown_waits_on_orchestrator_events() -> None:
     # shutdown returned → every orchestrator finalized.
     assert not orch_addr.is_alive()
     assert len(system.orchestrators) == 0
+
+
+# ---------------------------------------------------------------------------
+# Characterization — teardown recipient-resolution race (story 18.2)
+# ---------------------------------------------------------------------------
+
+
+def test_get_team_member_returns_none_for_stopped_member_during_teardown() -> None:
+    """Characterizes the teardown recipient-resolution race documented in story 18.2.
+
+    During teardown the roster shrinks as each agent emits its ``StopMessage``
+    (``get_team()`` shrinks). An agent still finishing its in-flight handler may
+    resolve a recipient against this shrinking roster via
+    ``Orchestrator.get_team_member(name)``. If the target has already stopped and
+    left the roster, the lookup returns ``None`` — and the agent-side router
+    drops the send silently (the silent-drop fix is an ``akgentic-agent``
+    follow-up, out of scope here).
+
+    This pins down the core-boundary behaviour: with ``_stopping`` set, a lookup
+    for an already-stopped member returns ``None``, while a still-running member
+    is still resolvable. Behaviour-only — no ADR-reference-string assertions
+    (Golden Rule #8).
+    """
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        ProbingOrchestrator,
+        config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
+    )
+    orch_proxy = system.proxy_ask(orch_addr, ProbingOrchestrator)
+
+    # Two members: the recipient (@Human, stopped first during teardown) and a
+    # still-running sender (@Worker) finishing its in-flight handler.
+    human_addr = orch_proxy.createActor(
+        TelemetryWorker, config=BaseConfig(name="@Human", role="HumanProxy")
+    )
+    worker_addr = orch_proxy.createActor(
+        TelemetryWorker, config=BaseConfig(name="@Worker", role="Worker")
+    )
+    assert human_addr is not None
+    assert worker_addr is not None
+
+    # Both are resolvable before any teardown.
+    assert orch_proxy.get_team_member("@Human") is not None
+    assert orch_proxy.get_team_member("@Worker") is not None
+
+    # @Human stops first (emits its StopMessage, leaves the roster) — the
+    # HumanProxy-torn-down-first case from the story. Blocking child stop keeps
+    # the orchestrator alive so we can probe its roster afterwards.
+    system.proxy_ask(human_addr, Akgent).stop()
+    time.sleep(0.2)  # let the StopMessage land and invalidate the roster cache
+
+    # Probe the roster the way a mid-handler agent would during teardown:
+    # _stopping is set on the orchestrator's own thread, then the lookups run.
+    human_lookup, worker_lookup = orch_proxy.probe_lookup_during_stopping(
+        "@Human", "@Worker"
+    )
+
+    # The stopped recipient resolves to None — the lookup miss that leads to the
+    # silent drop. The still-running sender is still resolvable.
+    assert human_lookup is None
+    assert worker_lookup is not None
+    assert worker_lookup.name == "@Worker"
+
+    system.shutdown()


### PR DESCRIPTION
## Summary

Documentation + characterization follow-up to Story 18.1 (non-blocking orchestrator stop, ADR-012, merged in PR #78).

Story 18.1 made orchestrator stop non-blocking by tearing the roster down incrementally: as each agent emits its `StopMessage`, `get_team()` shrinks. An agent still finishing its in-flight handler during this window resolves its recipient via `Orchestrator.get_team_member(name)` against the shrinking roster. If the target already stopped (e.g. `HumanProxy` torn down first), the lookup returns `None`, and the agent-side router silently skips the send — so no `SentMessage` telemetry is ever persisted.

This PR pins down that core-boundary behaviour with a behaviour-only characterization test. It changes **no production code**.

## In scope (this submodule branch / PR)

- **AC3** — `tests/core/test_orchestrator_stop.py`: a new characterization test
  (`test_get_team_member_returns_none_for_stopped_member_during_teardown`) asserting that with
  `_stopping=True`, `get_team_member(name)` returns `None` for a member that has already emitted its
  `StopMessage` and left the roster, while a still-running member stays resolvable. The lookup runs
  on the orchestrator's own actor thread (via a small `ProbingOrchestrator` subclass driven by
  `proxy_ask`), faithfully reproducing the mid-handler reentrant lookup.
- **AC4** — no production `src/` change. Verified: the commit touches only the test file (+80 lines).

## Out of scope

- **ADR-012 "Known interaction" section (AC1) and the Epic-18 Story 18.2 entry (AC2)** — these live
  in the parent repo under `_bmad-output/` and are handled separately by the lead; they are not part
  of this `akgentic-core` submodule branch.
- **The silent-drop fix** in `akgentic-agent` (`BaseAgent.process_message` should surface an
  unresolved recipient as an `ErrorMessage`/WARNING instead of dropping the send) — separate
  submodule, separate story/branch/PR per the cross-submodule rule.
- **Optional core-side WARNING** on a roster-lookup miss during `_stopping` — noted as a possible
  future mitigation; not required here.

## Scope guard

All changes in this branch stay inside `packages/akgentic-core/` (the single test file). No other
submodule and no parent-repo doc files are touched by this PR.

## Verification (local)

- `pytest tests/` — 496 passed, coverage 92.20% (gate ≥ 80%)
- `mypy src/` — clean (CI type-checks `src/` only; the new test code adds no mypy errors)
- `ruff check src/` and on the test file — clean
- Behaviour-only, no `ADR-NNN` string assertions (Golden Rule #8)

Closes #81
