### PR TITLE
feat(akgentic-core): 18-2 two-phase tool-agent stop gate

### DIFF
--- a/src/akgentic/core/orchestrator.py
+++ b/src/akgentic/core/orchestrator.py
@@ -264,6 +264,14 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._stop_event: threading.Event | None = None
         self._stop_backstop: threading.Timer | None = None
 
+        # Tool actors (name prefixed "#") deferred to phase 2 of the stop
+        # sequence (ADR-012 §2a): populated in phase 1 (reverse creation order)
+        # and CLEARED once told, which is the fire-once guard preventing a re-tell
+        # on every subsequent StopMessage. Tool actors stop only after every
+        # non-tool agent has fully stopped, so a consumer still inside a handler
+        # can never call a tool whose actor was already torn down.
+        self._pending_tool_stops: list[ActorAddress] = []
+
         # Event subscribers for Phase 3 extensibility
         self.subscribers: list[EventSubscriber] = []
 
@@ -428,6 +436,9 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._current_team_members = None  # Invalidate roster cache
 
         if self._stopping:
+            # PHASE 2 gate (ADR-012 §2a): once the non-tool roster has emptied,
+            # tell the deferred tool actors to stop (reverse creation order).
+            self._maybe_stop_pending_tools()
             if not self.get_team():  # whole tree down (GC-safe identity — ADR-012 §5)
                 self._finalize_stop()
             return  # suppress subscriber dispatch during teardown
@@ -717,11 +728,74 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
         self._timer.cancel()  # no inactivity auto-stop mid-teardown
         self._stopping = True
         self._stop_event = threading.Event()
-        self.stop_children(blocking=False)  # TELL children; do not block
+        self._stop_non_tool_children()  # PHASE 1: tell non-tool children; defer tools (§2a)
+        # Kick phase 2 now in case there are NO non-tool agents to wait for (a
+        # tools-only team): no StopMessage would ever arrive to drive the gate,
+        # so tell the tool actors straight away. A no-op when non-tool agents
+        # exist (the roster still has them) — the gate then fires on their stops.
+        self._maybe_stop_pending_tools()
         self._arm_stop_backstop(grace_timeout)  # guarantees the event sets (§4)
         if not self.get_team():  # zero-agent team: nothing will report
             self._finalize_stop()
         return self._stop_event
+
+    @staticmethod
+    def _is_tool_actor(addr: ActorAddress) -> bool:
+        """A tool actor is identified by the ``#`` name-prefix convention.
+
+        Tool actors (``#VectorStore``, ``#PlanningTool``, ``#KnowledgeGraphTool``,
+        ``#SandboxActor``, …) back the tools other agents call mid-handler; they
+        are stopped in phase 2, after every non-tool agent (ADR-012 §2a).
+        """
+        return addr.name.startswith("#")
+
+    def _live_children_reversed(self) -> list[ActorAddress]:
+        """Live children in REVERSE creation order.
+
+        ``_children`` preserves creation order (append-only in ``createActor``).
+        Tool actors are created in dependency order by ``ToolFactory``'s
+        topological sort (a prerequisite like ``#VectorStore`` is created before
+        its consumers ``#PlanningTool``/``#KnowledgeGraphTool``). Reversing that
+        order therefore stops consumers before their dependency — no runtime
+        ``depends_on`` lookup needed. INVARIANT: creation order encodes stop
+        order; do not reorder ``_children`` or drop the topological sort.
+        """
+        return [child for child in reversed(self._children) if child.is_alive()]
+
+    def _stop_non_tool_children(self) -> None:
+        """PHASE 1 of the stop sequence (ADR-012 §2a).
+
+        Tells every NON-tool child to stop (reverse creation order) and stashes
+        the tool actors in ``_pending_tool_stops`` (also reverse-ordered) for
+        phase 2. Tool actors stay alive here, so a consumer agent finishing its
+        in-flight handler can still invoke its tool.
+        """
+        reversed_live = self._live_children_reversed()
+        self._pending_tool_stops = [c for c in reversed_live if self._is_tool_actor(c)]
+        for child in reversed_live:
+            if not self._is_tool_actor(child):
+                self.proxy_tell(child, Akgent).stop()  # non-blocking tell
+
+    def _maybe_stop_pending_tools(self) -> None:
+        """PHASE 2 of the stop sequence (ADR-012 §2a).
+
+        Once no non-tool agent remains in the roster (every non-tool subtree has
+        emitted its ``StopMessage`` — the "fully stopped" signal), tell the
+        deferred tool actors to stop, in the reverse creation order captured in
+        phase 1 (consumers before their dependency, e.g. ``#PlanningTool`` before
+        ``#VectorStore``). Fires exactly once — guarded by ``_pending_tool_stops``.
+
+        The roster gate reads ``get_team()`` (whole-tree, telemetry-derived) so a
+        consumer's grandchildren must also be down before tools stop. Never blocks.
+        """
+        if not self._pending_tool_stops:
+            return
+        if any(not self._is_tool_actor(member) for member in self.get_team()):
+            return  # non-tool agents still alive — wait for the next StopMessage
+        for child in self._pending_tool_stops:  # already reverse-ordered (phase 1)
+            if child.is_alive():
+                self.proxy_tell(child, Akgent).stop()
+        self._pending_tool_stops = []
 
     def _arm_stop_backstop(self, grace_timeout: float) -> None:
         """Arm the backstop timer that forces teardown after ``grace_timeout``."""
@@ -760,6 +834,15 @@ class Orchestrator(Akgent[BaseConfig, BaseState]):
             logger.warning(
                 "Orchestrator stop timed out (team=%s); forcing teardown", self.team_id
             )
+            # A non-tool agent wedged before phase 2 fired, so the tool actors may
+            # still be un-told. Flush their stop tells (reverse order) for a last
+            # graceful chance before forcing teardown; any that wedge are reaped by
+            # ActorRegistry.stop_all() (ADR-012 §2a/§4). Non-blocking — the backstop
+            # must not block on a wedged child either.
+            for child in self._pending_tool_stops:
+                if child.is_alive():
+                    self.proxy_tell(child, Akgent).stop()
+            self._pending_tool_stops = []
             self.actor_ref.stop(block=False)
 
     # =============================================================================

--- a/tests/core/test_orchestrator_stop.py
+++ b/tests/core/test_orchestrator_stop.py
@@ -103,6 +103,79 @@ class WedgedWorker(Akgent):
         return None
 
 
+# ---------------------------------------------------------------------------
+# Tool-actor gate harness (story 18.2)
+# ---------------------------------------------------------------------------
+
+# Records the ORDER in which tool actors are told to stop (their ``stop()`` is
+# invoked). Behaviour-only: a test asserts on the sequence of tool names, never
+# on any ADR-reference string (Golden Rule #8). Reset by ``_reset_tool_state``.
+_tool_stop_order: list[str] = []
+
+# Captures whether a consumer could successfully invoke its tool DURING teardown
+# (after stop() was called, before the consumer's own StopMessage landed).
+_tool_invoke_ok = threading.Event()
+
+
+def _reset_tool_state() -> None:
+    """Clear the per-test tool-gate observation state."""
+    _tool_stop_order.clear()
+    _tool_invoke_ok.clear()
+
+
+class ToolActor(Akgent):
+    """A ``#``-prefixed tool actor backing a tool that ``@`` agents call.
+
+    Records its own name into ``_tool_stop_order`` when its ``stop`` runs, then
+    stops normally so its ``StopMessage`` telemetry still flows. NOTE: the tells
+    are fire-and-forget (``proxy_tell``), so this records *execution* order on each
+    tool's own thread — order-independent membership is what tests assert, not the
+    sequence. Exposes a trivial ``ping`` an in-flight consumer can ask to prove the
+    tool actor is still live during teardown.
+    """
+
+    def ping(self) -> str:
+        return self.config.name
+
+    def stop(self) -> None:  # type: ignore[override]
+        _tool_stop_order.append(self.config.name)
+        super().stop()
+
+
+class ToolConsumerWorker(Akgent):
+    """An ``@`` consumer that, mid-handler, invokes its ``#`` tool actor.
+
+    The tool address is published on the module-level ``_consumer_tool_ref`` holder
+    before the message is sent. The consumer enters its handler (sets
+    ``_in_handler``), holds it open so a stop() arrives while it is busy, then asks
+    the tool — which must still be alive (it is deferred to phase 2) — and records
+    success on ``_tool_invoke_ok``.
+    """
+
+    def receiveMsg_UserMessage(self, message: UserMessage, sender: ActorAddress) -> None:
+        _in_handler.set()
+        time.sleep(_HANDLER_HOLD_S)
+        tool = _consumer_tool_ref[0]
+        if tool is not None and tool.is_alive():
+            result = self.proxy_ask(tool, ToolActor).ping()
+            if result is not None:
+                _tool_invoke_ok.set()
+
+
+# Holder so a consumer can reach its tool address from inside its handler thread.
+_consumer_tool_ref: list[ActorAddress | None] = [None]
+
+
+def _create_tool(orch_proxy: Orchestrator, name: str) -> ActorAddress:
+    """Create a ``#``-prefixed tool actor as a direct child of the orchestrator."""
+    return orch_proxy.createActor(ToolActor, config=BaseConfig(name=name, role="Tool"))
+
+
+def _create_consumer(orch_proxy: Orchestrator, worker_cls: type[Akgent]) -> ActorAddress:
+    """Create an ``@``-prefixed non-tool consumer under the orchestrator."""
+    return orch_proxy.createActor(worker_cls, config=BaseConfig(name="@Consumer", role="Worker"))
+
+
 def _build_team(
     system: ActorSystem, worker_cls: type[Akgent]
 ) -> tuple[ActorAddress, ActorAddress, RecordingSubscriber]:
@@ -426,3 +499,181 @@ def test_subscriber_snapshots_gcd_telemetry_sender() -> None:
     assert snapshot.sender.serialize()["__actor_type__"].endswith(".TelemetryWorker")
 
     system.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Two-phase tool-agent stop gate (story 18.2, ADR-012 §2a)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_actor_stopped_only_after_non_tool_agents() -> None:
+    """AC3/AC5: a ``#`` tool actor is left alive + untold at stop() and is told to
+    stop only after the non-tool consumer (and its subtree) has fully stopped.
+
+    Consumer is created BEFORE the tool, so the tool is the later child; the
+    consumer holds its handler open, so its StopMessage lands well after stop().
+    """
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    consumer = _create_consumer(orch_proxy, TelemetryWorker)
+    tool = _create_tool(orch_proxy, "#VectorStore")
+
+    system.tell(consumer, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0), "consumer never entered its handler"
+
+    # PHASE 1: stop() tells the non-tool consumer, defers the tool actor.
+    event = orch_proxy.stop(5.0)
+    # The tool actor is still alive and has NOT been told to stop yet: the
+    # consumer is mid-handler and its StopMessage cannot have landed.
+    assert tool.is_alive()
+    assert _tool_stop_order == []
+
+    # PHASE 2: once the consumer's handler returns and its StopMessage lands, the
+    # deferred tool actor is told to stop and the team finalizes.
+    assert event.wait(timeout=10.0)
+    assert _tool_stop_order == ["#VectorStore"]
+    assert not tool.is_alive()
+    assert not orch_addr.is_alive()
+
+
+def test_consumer_can_invoke_tool_during_teardown() -> None:
+    """AC3: a consumer finishing its in-flight handler can still invoke its ``#``
+    tool actor after stop() is called and before its own StopMessage lands."""
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    consumer = _create_consumer(orch_proxy, ToolConsumerWorker)
+    tool = _create_tool(orch_proxy, "#VectorStore")
+    _consumer_tool_ref[0] = tool
+
+    system.tell(consumer, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0), "consumer never entered its handler"
+
+    # Stop while the consumer is mid-handler; it will ask its tool before finishing.
+    event = orch_proxy.stop(5.0)
+    assert event.wait(timeout=10.0)
+
+    # The mid-teardown tool invocation succeeded (no dead-actor crash): the tool
+    # was still alive when the consumer called it.
+    assert _tool_invoke_ok.is_set()
+    assert not orch_addr.is_alive()
+
+
+def test_multiple_tool_actors_all_stopped_after_non_tool_agents() -> None:
+    """AC2/AC5: a team with two ``#`` tool actors tears them BOTH down — after the
+    non-tool consumer has stopped — when the gate fires.
+
+    The orchestrator *dispatches* the stop tells in reverse creation order —
+    ``_pending_tool_stops`` is built from ``_live_children_reversed()`` (a pure
+    list reversal), so the dispatch order is correct by construction. The order
+    the tool actors then *execute* their stop is NOT asserted here: the tells are
+    fire-and-forget (``proxy_tell``), so each tool runs its ``stop`` on its own
+    thread and the completion order is a scheduling detail, not a contract.
+    """
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    consumer = _create_consumer(orch_proxy, TelemetryWorker)
+    tool_a = _create_tool(orch_proxy, "#VectorStore")  # dependency, created first
+    tool_b = _create_tool(orch_proxy, "#PlanningTool")  # consumer of A, created last
+
+    system.tell(consumer, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    event = orch_proxy.stop(5.0)
+    assert event.wait(timeout=10.0)
+
+    # Both tool actors were told to stop and are down; order-independent.
+    assert set(_tool_stop_order) == {"#PlanningTool", "#VectorStore"}
+    assert not tool_a.is_alive()
+    assert not tool_b.is_alive()
+
+
+def test_tools_only_team_stops_immediately() -> None:
+    """AC4: a team whose only children are ``#`` tool actors finalizes promptly —
+    phase 2 is kicked from stop() itself, with no non-tool StopMessage needed."""
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    tool_a = _create_tool(orch_proxy, "#VectorStore")
+    tool_b = _create_tool(orch_proxy, "#PlanningTool")
+
+    # No non-tool agent → no StopMessage would ever drive the gate; stop() itself
+    # must kick phase 2 and tear both tools down (dispatch order is reverse
+    # creation order by construction; execution/completion order is a scheduling
+    # detail and is not asserted).
+    event = orch_proxy.stop(5.0)
+    assert event.wait(timeout=10.0)
+    assert set(_tool_stop_order) == {"#PlanningTool", "#VectorStore"}
+    assert not tool_a.is_alive()
+    assert not tool_b.is_alive()
+    assert not orch_addr.is_alive()
+
+
+def test_backstop_flushes_pending_tool_actors(caplog: pytest.LogCaptureFixture) -> None:
+    """AC6: a wedged non-tool agent prevents phase 2 → the backstop _force_stop
+    still tells the deferred tool actors to stop before forcing teardown, with a
+    WARNING logged."""
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    consumer = _create_consumer(orch_proxy, WedgedWorker)
+    tool = _create_tool(orch_proxy, "#VectorStore")
+
+    system.tell(consumer, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    grace = 1.0
+    with caplog.at_level(logging.WARNING):
+        event = orch_proxy.stop(grace)
+        # The wedged consumer never emits its StopMessage, so phase 2 cannot fire
+        # on its own; the tool stays deferred until the backstop flushes it.
+        assert not event.wait(timeout=0.3)
+        assert event.wait(timeout=grace + 5.0)
+
+    # The backstop flushed the deferred tool actor (graceful tell) before forcing.
+    assert _tool_stop_order == ["#VectorStore"]
+    assert not tool.is_alive()
+    assert any("forcing teardown" in rec.message for rec in caplog.records)
+
+
+def test_completion_waits_for_whole_roster_including_tools() -> None:
+    """AC7: the stop event fires only after the tool actors have ALSO stopped —
+    not when only the non-tool roster has emptied."""
+    _reset_tool_state()
+    system = ActorSystem()
+    orch_addr = system.createActor(
+        Orchestrator, config=BaseConfig(name="@Orchestrator", role="Orchestrator")
+    )
+    orch_proxy = system.proxy_ask(orch_addr, Orchestrator)
+    consumer = _create_consumer(orch_proxy, TelemetryWorker)
+    tool = _create_tool(orch_proxy, "#VectorStore")
+
+    system.tell(consumer, UserMessage(content="hello"))
+    assert _in_handler.wait(timeout=5.0)
+
+    event = orch_proxy.stop(5.0)
+    assert event.wait(timeout=10.0)
+
+    # The completion event sets (in the orchestrator's on_stop) only after the
+    # whole roster — tool actors included — has emptied: the tool actor was told
+    # to stop and is down, and the orchestrator has finalized.
+    assert _tool_stop_order == ["#VectorStore"]
+    assert not tool.is_alive()
+    assert not orch_addr.is_alive()


### PR DESCRIPTION
## Summary

Adds a two-phase, event-driven tool-agent stop gate to the orchestrator so that `#`-prefixed tool actors are torn down **only after** every non-tool (`@`) agent and its whole subtree has fully stopped, in reverse creation order.

- **Phase 1 (`stop()` → `_stop_non_tool_children`)**: tell every non-tool child to stop (reverse creation order) and stash the live tool actors in `_pending_tool_stops` (also reverse-ordered). Tool actors stay alive, so a consumer finishing its in-flight handler can still invoke its tool.
- **Phase 2 (`_maybe_stop_pending_tools`)**: once `get_team()` (whole-tree, telemetry-derived) contains only `#`-prefixed members, tell the deferred tool actors to stop and clear the list. Fires exactly once; driven by each non-tool `StopMessage` in `receiveMsg_StopMessage`. `stop()` also kicks phase 2 immediately so a tools-only team (no non-tool `StopMessage` to wait on) finalizes promptly.
- **Backstop flush (`_force_stop`)**: if a non-tool agent wedges before phase 2 fires, flush the remaining `_pending_tool_stops` with non-blocking stop tells before forcing teardown; any that still wedge are reaped by `ActorRegistry.stop_all()`.

Reverse creation order encodes stop order: `ToolFactory`'s topological sort creates a dependency (e.g. `#VectorStore`) before its consumers, so reversing `_children` stops consumers first with no runtime `depends_on` lookup. The orchestrator never blocks; completion semantics are unchanged (the stop event fires only when the whole roster — tool actors included — empties).

Relates to #83

## Scope guard

All changes stay inside `packages/akgentic-core/`:
- `src/akgentic/core/orchestrator.py` — `_pending_tool_stops` init in `on_start`; `_is_tool_actor`, `_live_children_reversed`, `_stop_non_tool_children`, `_maybe_stop_pending_tools`; `stop()` phase-1 + tools-only kick; `receiveMsg_StopMessage` phase-2 gate; `_force_stop` flush.
- `tests/core/test_orchestrator_stop.py` — six tool-actor gate behaviour tests.

No edits to any other submodule. `Akgent.stop_children` stays unchanged and prefix-agnostic.

## Verification

- `pytest packages/akgentic-core/tests/` — **507 passed** (incl. all 18.1 stop tests and `test_pykka_mailbox_drain_on_self_stop.py`)
- `mypy packages/akgentic-core/src/` — clean (17 files)
- `ruff check` — clean
- Tests assert behaviour only; multi-tool teardown asserts order-independent set membership (tool stops are fire-and-forget `proxy_tell` on per-tool threads), avoiding flaky ordered assertions. No `ADR-NNN` test-string assertions (Golden Rule #8).

## Review status

**PASS** — All seven ACs (AC1–AC7) implemented and verified. No HIGH or MEDIUM findings. Reverse-creation-order dispatch is correct by construction; the gate is fire-once and never blocks. One benign LOW (cross-thread `_pending_tool_stops` mutation in `_force_stop` from the Timer thread) is consistent with the pre-existing 18.1 backstop threading model and harmless under idempotent `proxy_tell` — not blocking.
